### PR TITLE
fix: stop CalDAV poll re-sending event notifications every cycle

### DIFF
--- a/source/nc_calendar.py
+++ b/source/nc_calendar.py
@@ -716,13 +716,13 @@ def poll_events():
                 except Exception as e:
                     logger.exception(f"CALDAV: ой {e}")
 
-            if not caldav_error_occurred:
-                deleted_events_uids = all_sended_events_uids - current_found_uids
-                for del_uid in deleted_events_uids:
-                    try:
-                        # set_all_attendees_needs_action(del_uid)
-                        delete_event_sends(del_uid)
-                    except Exception as e:
-                        logger.error(f"CALDAV: Ошибка удаления события из БД: {e}")
+        if not caldav_error_occurred:
+            deleted_events_uids = all_sended_events_uids - current_found_uids
+            for del_uid in deleted_events_uids:
+                try:
+                    # set_all_attendees_needs_action(del_uid)
+                    delete_event_sends(del_uid)
+                except Exception as e:
+                    logger.error(f"CALDAV: Ошибка удаления события из БД: {e}")
 
         sleep(POLL_INTERVAL)


### PR DESCRIPTION
## Что

В `poll_events` ([source/nc_calendar.py](source/nc_calendar.py)) блок очистки БД от ушедших событий был вложен внутрь `for calendar in calendars:`. Дедентим его на один уровень, чтобы он отрабатывал один раз за тик — уже после полного обхода всех календарей.

## Почему

`all_sended_events_uids` читается из БД один раз в начале тика, а `current_found_uids` наполняется постепенно по мере обхода календарей. При вложенном `if not caldav_error_occurred:` после первого календаря `current_found_uids` содержал UIDы только этого календаря, и `delete_event_sends` стирал из таблицы `caldav_send_data` строки для событий из всех остальных календарей. На следующем `POLL_INTERVAL` (в проде ~180с) эти события снова считались новыми и рассылались повторно — отсюда жалобы на дубли уведомлений примерно раз в 3 минуты.

После фикса diff `all_sended - current_found` считается уже на финальном множестве UIDов из всех календарей, и удаляются из БД только реально исчезнувшие события.

Флаг `caldav_error_occurred` ([nc_calendar.py:592](source/nc_calendar.py:592)) ведёт себя как ожидалось: если хоть один календарь упал на запросе — очистка за этот тик пропускается целиком (иначе сетевой сбой опять спровоцировал бы массовую повторную рассылку).

## Что проверить ревьюверу

- [ ] Один тик `poll_events` с несколькими календарями в Nextcloud: события из не-последнего календаря не приходят повторно.
- [ ] Если один из календарей отвалился — никакие строки из `caldav_send_data` не удалились.
- [ ] Удалённое в Nextcloud событие действительно вычищается из БД на следующем тике (после правки очистка по-прежнему работает, просто теперь корректно).