### PR TITLE
fix(caldav): keep periodic cleanup read-only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,32 +11,48 @@ permissions:
 
 jobs:
   test:
+    name: Quality (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
             source/requirements.txt
+            requirements-dev.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
-          pip install -r source/requirements.txt
+          python -m pip install \
+            -r source/requirements.txt \
+            -r requirements-dev.txt
 
-      - name: Run linter - hard errors only
+      - name: Run Ruff linter
         run: |
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          ruff check \
+            source/caldav_notification_state.py \
+            source/db/repos/caldav_calendar.py \
+            tests
 
-      - name: Run linter - soft style guide
+      - name: Check Ruff formatting
         run: |
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics
+          ruff format --check \
+            source/caldav_notification_state.py \
+            source/db/repos/caldav_calendar.py \
+            tests
+
+      - name: Run unit tests
+        run: pytest -q
 
   build-and-push:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ source/db/__pycache__/
 source/db/repos/__pycache__/
 source/migrations/__pycache__/
 alembic
+__pycache__/
+.coverage
+.pytest_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[tool.ruff]
+target-version = "py311"
+line-length = 79
+indent-width = 4
+
+[tool.ruff.lint]
+select = [
+    "E4",
+    "E7",
+    "E9",
+    "E501",
+    "F",
+    "I",
+    "B",
+    "C4",
+    "SIM",
+    "UP",
+    "RUF",
+    "PT",
+    "W505",
+]
+
+[tool.ruff.lint.pycodestyle]
+max-doc-length = 72
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"
+
+[tool.pytest.ini_options]
+minversion = "9.1"
+testpaths = ["tests"]
+addopts = [
+    "--strict-config",
+    "--strict-markers",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,4 +34,8 @@ testpaths = ["tests"]
 addopts = [
     "--strict-config",
     "--strict-markers",
+    "--cov=source.caldav_notification_state",
+    "--cov-branch",
+    "--cov-report=term-missing",
+    "--cov-fail-under=100",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest==9.1.1
+pytest-cov==7.1.0
+ruff==0.16.2

--- a/source/caldav_notification_state.py
+++ b/source/caldav_notification_state.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class SentEventKey:
+    telegram_id: int
+    cooldown_minutes: int
+    event_uid: str
+
+
+def find_stale_keys(
+    saved_keys: set[SentEventKey],
+    observed_keys: set[SentEventKey],
+    *,
+    scan_complete: bool,
+) -> set[SentEventKey]:
+    if not scan_complete:
+        return set()
+
+    return saved_keys - observed_keys

--- a/source/db/repos/caldav_calendar.py
+++ b/source/db/repos/caldav_calendar.py
@@ -1,54 +1,83 @@
-from typing import Optional, Set
+from sqlalchemy import delete, select
 
-from sqlalchemy import select, delete
-
+from source.caldav_notification_state import SentEventKey
 from source.db.db import get_session
 from source.migrations.models import CalDavSendData
 
 
-def get_events_from_db() -> Set[str]:
-    """Возвращает set строк в формате {tg_id}_{cooldown}_{event_name} из БД."""
+def get_sent_event_keys() -> set[SentEventKey]:
+    """Return the notification keys currently stored in the database."""
     with get_session() as session:
-        stmt = select(CalDavSendData.tg_id, CalDavSendData.cooldown, CalDavSendData.event_name)
-        result = session.execute(stmt).all()
-        return {f"{row.tg_id}_{row.cooldown}_{row.event_name}" for row in result}
+        stmt = select(
+            CalDavSendData.tg_id,
+            CalDavSendData.cooldown,
+            CalDavSendData.event_name,
+        )
+        rows = session.execute(stmt).all()
+        return {
+            SentEventKey(
+                telegram_id=row.tg_id,
+                cooldown_minutes=row.cooldown,
+                event_uid=row.event_name,
+            )
+            for row in rows
+        }
 
 
-def get_url_by_id(t_id: int) -> Optional[str]:
+def get_url_by_id(t_id: int) -> str | None:
     """Возвращает URL события по ID."""
     with get_session() as session:
         event = session.get(CalDavSendData, t_id)
         return event.url if event else None
 
 
-def get_name_by_id(t_id: int) -> Optional[str]:
+def get_name_by_id(t_id: int) -> str | None:
     """Возвращает event_name по ID."""
     with get_session() as session:
         event = session.get(CalDavSendData, t_id)
         return event.event_name if event else None
 
 
-def get_id_by_name(name: str) -> Optional[int]:
+def get_id_by_name(name: str) -> int | None:
     """Возвращает ID события по event_name."""
     with get_session() as session:
-        stmt = select(CalDavSendData).where(CalDavSendData.event_name == name)
+        stmt = select(CalDavSendData).where(
+            CalDavSendData.event_name == name,
+        )
         event = session.execute(stmt).scalar_one_or_none()
         return event.id if event else None
 
 
-def save_event_sends(name: str, tg_id: int, cooldown: int, event_name: str, url: str) -> None:
+def save_event_send(
+    name: str,
+    key: SentEventKey,
+    url: str,
+) -> None:
     """Сохраняет новое событие (игнорирует дубликаты)."""
     with get_session() as session:
-        # Проверяем существование
-        stmt = select(CalDavSendData).where(CalDavSendData.event_name == event_name, CalDavSendData.tg_id == tg_id, CalDavSendData.cooldown == cooldown)
+        stmt = select(CalDavSendData).where(
+            CalDavSendData.event_name == key.event_uid,
+            CalDavSendData.tg_id == key.telegram_id,
+            CalDavSendData.cooldown == key.cooldown_minutes,
+        )
         existing = session.execute(stmt).scalar_one_or_none()
         if not existing:
-            event = CalDavSendData(name=name, tg_id=tg_id, cooldown=cooldown, event_name=event_name, url=url)
+            event = CalDavSendData(
+                name=name,
+                tg_id=key.telegram_id,
+                cooldown=key.cooldown_minutes,
+                event_name=key.event_uid,
+                url=url,
+            )
             session.add(event)
 
 
-def delete_event_sends(name: str) -> None:
-    """Удаляет событие по event_name."""
+def delete_sent_event(key: SentEventKey) -> None:
+    """Delete one exact notification record."""
     with get_session() as session:
-        stmt = delete(CalDavSendData).where(CalDavSendData.event_name == name)
+        stmt = delete(CalDavSendData).where(
+            CalDavSendData.tg_id == key.telegram_id,
+            CalDavSendData.cooldown == key.cooldown_minutes,
+            CalDavSendData.event_name == key.event_uid,
+        )
         session.execute(stmt)

--- a/source/db/repos/caldav_calendar.py
+++ b/source/db/repos/caldav_calendar.py
@@ -6,7 +6,7 @@ from source.migrations.models import CalDavSendData
 
 
 def get_sent_event_keys() -> set[SentEventKey]:
-    """Return the notification keys currently stored in the database."""
+    """Возвращает ключи отправленных уведомлений из базы данных."""
     with get_session() as session:
         stmt = select(
             CalDavSendData.tg_id,
@@ -73,7 +73,7 @@ def save_event_send(
 
 
 def delete_sent_event(key: SentEventKey) -> None:
-    """Delete one exact notification record."""
+    """Удаляет точную запись отправленного уведомления."""
     with get_session() as session:
         stmt = delete(CalDavSendData).where(
             CalDavSendData.tg_id == key.telegram_id,

--- a/source/nc_calendar.py
+++ b/source/nc_calendar.py
@@ -3,7 +3,12 @@ from source.config import WEB_CALDAV_URL, USERNAME, PASSWORD, COOLDOWN_TUESDAY, 
 from source.connections.sender import send_message_limited
 from source.db.repos.users import get_tg_id_by_email, save_email_by_username, get_timezone
 from source.app_logging import logger
-from source.db.repos.caldav_calendar import get_events_from_db, save_event_sends, delete_event_sends, get_id_by_name
+from source.caldav_notification_state import SentEventKey, find_stale_keys
+from source.db.repos.caldav_calendar import (
+    delete_sent_event,
+    get_sent_event_keys,
+    save_event_send,
+)
 from telebot.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 from caldav import DAVClient, error
@@ -608,9 +613,9 @@ def poll_events():
         start = datetime.now(TEAM_TZ)
 
         end = start + timedelta(days=1)
-        all_sended_events_uids = get_events_from_db()
-        current_found_uids = set()
-        caldav_error_occurred = False
+        saved_event_keys = get_sent_event_keys()
+        observed_event_keys: set[SentEventKey] = set()
+        scan_complete = True
 
         try:
             calendars = principal.calendars()
@@ -624,7 +629,7 @@ def poll_events():
                 events = calendar.date_search(start=start, end=end)
             except Exception as e:
                 logger.error(f"CALDAV: Ошибка поиска событий в календаре: {e}")
-                caldav_error_occurred = True
+                scan_complete = False
                 continue
 
             for event in events:
@@ -667,33 +672,45 @@ def poll_events():
 
                             attendees = get_all_participants(component)
                             name_for_send = ""
-                            teg_id_and_uid = event_uid
-                            list_not_send_tg_id = []
-                            now_cooldown_send = cooldowns[0]
+                            pending_event_keys: dict[int, SentEventKey] = {}
                             if attendees:
                                 for user in attendees:
                                     email = user.get('email')
                                     if email is None:
                                         continue
                                     tg_id_found = get_tg_id_by_email(email)
-                                    for i in cooldowns:
-                                        teg_id_and_uid = f"{tg_id_found}_{i}_{event_uid}"
-                                        current_found_uids.add(teg_id_and_uid)
-                                        if teg_id_and_uid not in all_sended_events_uids:
-                                            now_cooldown_send = i
-                                            break
-
-                                    if teg_id_and_uid in all_sended_events_uids:
-                                        list_not_send_tg_id.append(tg_id_found)
+                                    if tg_id_found is None:
                                         continue
-
-                                    all_sended_events_uids.add(teg_id_and_uid)
+                                    user_event_keys = [
+                                        SentEventKey(
+                                            telegram_id=tg_id_found,
+                                            cooldown_minutes=cooldown,
+                                            event_uid=event_uid,
+                                        )
+                                        for cooldown in cooldowns
+                                    ]
+                                    observed_event_keys.update(
+                                        user_event_keys
+                                    )
+                                    pending_event_key = next(
+                                        (
+                                            key
+                                            for key in user_event_keys
+                                            if key not in saved_event_keys
+                                        ),
+                                        None,
+                                    )
+                                    if pending_event_key is not None:
+                                        pending_event_keys[
+                                            tg_id_found
+                                        ] = pending_event_key
 
                                 for user in attendees:
                                     email = user.get('email')
                                     if email is None:
                                         continue
                                     teg_id = get_tg_id_by_email(email)
+                                    event_key = pending_event_keys.get(teg_id)
 
                                     tz_user = get_timezone(teg_id)
 
@@ -752,7 +769,7 @@ def poll_events():
                                     if res[-1] == '\n': res = res[:-1]
                                     res += '///'
 
-                                    if teg_id and teg_id not in list_not_send_tg_id:
+                                    if teg_id and event_key is not None:
                                         markup = InlineKeyboardMarkup()
                                         if short_url is not None:
                                             accept = "success" if user['status'] == "ACCEPTED" else None
@@ -772,19 +789,30 @@ def poll_events():
                                             else:
                                                 markup.row(btn_update)
                                         send_message_limited(teg_id, res, reply_markup=markup)
-                                        save_event_sends(name_for_send, teg_id, now_cooldown_send, event_uid, event_url)
+                                        save_event_send(
+                                            name_for_send,
+                                            event_key,
+                                            event_url,
+                                        )
+                                        saved_event_keys.add(event_key)
 
                 except Exception as e:
+                    scan_complete = False
                     logger.exception(f"CALDAV: ой {e}")
 
-        if not caldav_error_occurred:
-            deleted_events_uids = all_sended_events_uids - current_found_uids
-            for del_uid in deleted_events_uids:
-                try:
-                    uid_for_delete = del_uid.split('_')[-1]
-                    set_all_attendees_needs_action(uid_for_delete)
-                    delete_event_sends(uid_for_delete)
-                except Exception as e:
-                    logger.error(f"CALDAV: Ошибка удаления события из БД: {e}")
+        stale_keys = find_stale_keys(
+            saved_event_keys,
+            observed_event_keys,
+            scan_complete=scan_complete,
+        )
+        for stale_key in stale_keys:
+            try:
+                set_all_attendees_needs_action(stale_key.event_uid)
+                delete_sent_event(stale_key)
+            except Exception as e:
+                logger.error(
+                    "CALDAV: Ошибка удаления "
+                    f"события из БД: {e}"
+                )
 
         sleep(POLL_INTERVAL)

--- a/source/nc_calendar.py
+++ b/source/nc_calendar.py
@@ -637,7 +637,11 @@ def poll_events():
                                     if email is None:
                                         continue
                                     teg_id = get_tg_id_by_email(email)
+                                    if teg_id is None:
+                                        continue
                                     event_key = pending_event_keys.get(teg_id)
+                                    if event_key is None:
+                                        continue
 
                                     tz_user = get_timezone(teg_id)
 

--- a/source/nc_calendar.py
+++ b/source/nc_calendar.py
@@ -530,79 +530,6 @@ def update_event_partstat(event_uid: str, user_email: str, new_status: str) -> b
         return False
 
 
-def set_all_attendees_needs_action(event_uid: str) -> bool:
-    """
-    Устанавливает статус NEEDS-ACTION (Ожидает решения)
-    для всех участников (ATTENDEE) указанного события.
-
-    event_uid: UID события
-    """
-    try:
-        start = datetime.now(TEAM_TZ)
-        end = start + timedelta(days=7)
-
-        client = DAVClient(WEB_CALDAV_URL, username=CALDAV_USERNAME, password=CALDAV_PASSWORD)
-        principal = client.principal()
-
-        target_event = None
-
-        calendars = principal.calendars()
-        for calendar in calendars:
-            try:
-                events = calendar.date_search(start=start, end=end, expand=True)
-                for event in events:
-                    ical = event.icalendar_instance
-                    for component in ical.walk('VEVENT'):
-                        if str(component.get('UID')) == event_uid:
-                            target_event = event
-                            logger.info(f"Событие найдено в календаре '{calendar.name}', {component.get('summary')} {component.get('dtstart').dt}")
-                            break
-                    if target_event: break
-            except Exception as e:
-                logger.debug(f"Пропуск календаря {calendar.name}: {e}")
-                continue
-            if target_event: break
-
-        if not target_event:
-            logger.error(f"Не удалось найти событие {event_uid} для сброса статусов")
-            return False
-
-        ical = target_event.icalendar_instance
-        updated = False
-
-        for component in ical.walk('VEVENT'):
-            if str(component.get('UID')) != event_uid:
-                continue
-
-            attendees = component.get('ATTENDEE')
-            if not attendees:
-                continue
-
-            if not isinstance(attendees, list):
-                attendees = [attendees]
-
-            for attendee in attendees:
-                attendee.params['PARTSTAT'] = [vText('NEEDS-ACTION')]
-                attendee.params['RSVP'] = [vText('TRUE')]
-                updated = True
-
-        if updated:
-            target_event.icalendar_instance = ical
-            try:
-                target_event.save()
-                logger.info(f"Статус 'NEEDS-ACTION' успешно установлен для всех участников события {event_uid}")
-                return True
-            except Exception as e:
-                logger.error(f"Ошибка сохранения события {event_uid}: {e}")
-                return False
-        else:
-            logger.warning(f"У события {event_uid} нет списка участников (ATTENDEE). Изменять нечего.")
-            return False
-
-    except Exception as e:
-        logger.exception(f"Критический сбой функции set_all_attendees_needs_action: {e}")
-        return False
-
 def poll_events():
     client = DAVClient(WEB_CALDAV_URL, username=CALDAV_USERNAME, password=CALDAV_PASSWORD)
     principal = client.principal()
@@ -807,7 +734,6 @@ def poll_events():
         )
         for stale_key in stale_keys:
             try:
-                set_all_attendees_needs_action(stale_key.event_uid)
                 delete_sent_event(stale_key)
             except Exception as e:
                 logger.error(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the Telegram bot."""

--- a/tests/caldav_fakes.py
+++ b/tests/caldav_fakes.py
@@ -1,0 +1,210 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import ClassVar
+from unittest.mock import Mock
+
+from source.caldav_notification_state import SentEventKey
+
+
+class StopPolling(Exception):
+    pass
+
+
+class FrozenDateTime(datetime):
+    current: ClassVar["FrozenDateTime"]
+
+    @classmethod
+    def now(cls, tz=None):
+        if tz is None:
+            return cls.current.replace(tzinfo=None)
+
+        return cls.current.astimezone(tz)
+
+
+@dataclass(frozen=True)
+class DateProperty:
+    dt: datetime
+
+
+class FakeComponent:
+    name = "VEVENT"
+
+    def __init__(
+        self,
+        values: dict[str, object],
+        *,
+        participants: list[dict[str, object]] | None = None,
+    ) -> None:
+        self._values = {key.upper(): value for key, value in values.items()}
+        self.participants = participants or []
+
+    def get(self, key: str, default=None):
+        return self._values.get(key.upper(), default)
+
+
+class FakeICalendar:
+    def __init__(self, components: list[FakeComponent]) -> None:
+        self.components = components
+
+    def walk(self, name: str | None = None) -> list[FakeComponent]:
+        if name is None:
+            return list(self.components)
+
+        return [
+            component
+            for component in self.components
+            if component.name == name.upper()
+        ]
+
+
+class FakeEvent:
+    def __init__(
+        self,
+        calendar_data: FakeICalendar,
+        *,
+        url: str = "https://calendar.test/event.ics",
+    ) -> None:
+        self.data = calendar_data
+        self.url = url
+        self.icalendar_instance = calendar_data
+        self.save = Mock()
+
+
+class FakeCalendar:
+    def __init__(
+        self,
+        events: list[FakeEvent] | None = None,
+        *,
+        error: Exception | None = None,
+        name: str = "Team",
+    ) -> None:
+        self.events = events or []
+        self.error = error
+        self.name = name
+        self.expand_calls: list[bool] = []
+
+    def date_search(
+        self,
+        *,
+        start: object,
+        end: object,
+        expand: bool = False,
+    ) -> list[FakeEvent]:
+        self.expand_calls.append(expand)
+        if self.error is not None:
+            raise self.error
+
+        return list(self.events)
+
+
+class FakePrincipal:
+    def __init__(self, calendars: list[FakeCalendar]) -> None:
+        self._calendars = calendars
+
+    def calendars(self) -> list[FakeCalendar]:
+        return list(self._calendars)
+
+
+class FakeClient:
+    def __init__(self, principal: FakePrincipal) -> None:
+        self._principal = principal
+
+    def principal(self) -> FakePrincipal:
+        return self._principal
+
+
+class FakeCalendarParser:
+    @staticmethod
+    def from_ical(data: FakeICalendar) -> FakeICalendar:
+        return data
+
+
+class FakeInlineKeyboardButton:
+    def __init__(
+        self,
+        text: str,
+        *,
+        style: str | None = None,
+        callback_data: str | None = None,
+    ) -> None:
+        self.text = text
+        self.style = style
+        self.callback_data = callback_data
+
+
+class FakeInlineKeyboardMarkup:
+    def __init__(self) -> None:
+        self.rows: list[tuple[FakeInlineKeyboardButton, ...]] = []
+
+    def row(self, *buttons: FakeInlineKeyboardButton) -> None:
+        self.rows.append(buttons)
+
+
+class FakeLogger:
+    def _ignore(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    debug = _ignore
+    error = _ignore
+    exception = _ignore
+    info = _ignore
+    warning = _ignore
+
+
+class FakeAttendee:
+    def __init__(self, email: str) -> None:
+        self.email = email
+        self.params = {
+            "PARTSTAT": ["NEEDS-ACTION"],
+            "RSVP": ["TRUE"],
+        }
+
+    def __str__(self) -> str:
+        return f"mailto:{self.email}"
+
+
+@dataclass
+class InMemoryNotificationState:
+    keys: set[SentEventKey] = field(default_factory=set)
+    saved: list[SentEventKey] = field(default_factory=list)
+    deleted: list[SentEventKey] = field(default_factory=list)
+
+    def load(self) -> set[SentEventKey]:
+        return set(self.keys)
+
+    def save(
+        self,
+        _name: str,
+        key: SentEventKey,
+        _url: str,
+    ) -> None:
+        self.keys.add(key)
+        self.saved.append(key)
+
+    def delete(self, key: SentEventKey) -> None:
+        self.keys.discard(key)
+        self.deleted.append(key)
+
+
+def make_poll_event(
+    *,
+    event_uid: str,
+    summary: str,
+    start: datetime,
+    end: datetime,
+    participants: list[dict[str, object]],
+    ical_attendees: FakeAttendee | list[FakeAttendee] | None = None,
+) -> FakeEvent:
+    values = {
+        "UID": event_uid,
+        "SUMMARY": summary,
+        "DESCRIPTION": "Weekly team sync",
+        "LOCATION": "Online",
+        "DTSTART": DateProperty(start),
+        "DTEND": DateProperty(end),
+    }
+    if ical_attendees is not None:
+        values["ATTENDEE"] = ical_attendees
+
+    component = FakeComponent(values, participants=participants)
+    return FakeEvent(FakeICalendar([component]))

--- a/tests/test_caldav_notification_state.py
+++ b/tests/test_caldav_notification_state.py
@@ -1,0 +1,38 @@
+from source.caldav_notification_state import SentEventKey, find_stale_keys
+
+
+def test_find_stale_keys_returns_unobserved_keys() -> None:
+    stale_key = SentEventKey(
+        telegram_id=101,
+        cooldown_minutes=60,
+        event_uid="team_sync_2026_instance",
+    )
+    observed_key = SentEventKey(
+        telegram_id=202,
+        cooldown_minutes=60,
+        event_uid="team_sync_2026_instance",
+    )
+
+    result = find_stale_keys(
+        {stale_key, observed_key},
+        {observed_key},
+        scan_complete=True,
+    )
+
+    assert result == {stale_key}
+
+
+def test_find_stale_keys_preserves_state_after_incomplete_scan() -> None:
+    saved_key = SentEventKey(
+        telegram_id=101,
+        cooldown_minutes=60,
+        event_uid="team_sync_2026_instance",
+    )
+
+    result = find_stale_keys(
+        {saved_key},
+        set(),
+        scan_complete=False,
+    )
+
+    assert result == set()

--- a/tests/test_caldav_polling.py
+++ b/tests/test_caldav_polling.py
@@ -1,0 +1,547 @@
+import ast
+import importlib
+import inspect
+import sys
+import textwrap
+from datetime import timedelta, timezone
+from types import ModuleType
+from unittest.mock import Mock
+
+import pytest
+
+from source.caldav_notification_state import SentEventKey
+from tests.caldav_fakes import (
+    FakeAttendee,
+    FakeCalendar,
+    FakeCalendarParser,
+    FakeClient,
+    FakeComponent,
+    FakeEvent,
+    FakeICalendar,
+    FakeInlineKeyboardButton,
+    FakeInlineKeyboardMarkup,
+    FakeLogger,
+    FakePrincipal,
+    FrozenDateTime,
+    InMemoryNotificationState,
+    StopPolling,
+    make_poll_event,
+)
+
+EVENT_UID = "team_sync_2026"
+USER_EMAIL = "user@example.com"
+USER_ID = 101
+COOLDOWN = 60
+
+
+def _module(name: str, **attributes: object) -> ModuleType:
+    module = ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    return module
+
+
+def _empty_keys() -> set[SentEventKey]:
+    return set()
+
+
+def _ignore(*_args: object, **_kwargs: object) -> None:
+    pass
+
+
+@pytest.fixture
+def nc_calendar(monkeypatch: pytest.MonkeyPatch):
+    config = _module(
+        "source.config",
+        WEB_CALDAV_URL="https://calendar.test/caldav",
+        USERNAME="nextcloud-user",
+        PASSWORD="nextcloud-password",
+        COOLDOWN_TUESDAY=2,
+        COOLDOWN_SUNDAY=10,
+        COOLDOWN_DEFAULT=2,
+        POLL_INTERVAL=60,
+        WEB_APP_URL="https://nextcloud.test",
+        UPDATE_INTERVAL=1,
+        TIMEZONE="Europe/Moscow",
+        CALDAV_USERNAME="caldav-user",
+        CALDAV_PASSWORD="caldav-password",
+        CALDAV_COOLDOWNS={"Team": [COOLDOWN]},
+        TIMEZONES={3: timezone(timedelta(hours=3))},
+    )
+    sender = _module(
+        "source.connections.sender",
+        send_message_limited=_ignore,
+    )
+    users = _module(
+        "source.db.repos.users",
+        get_tg_id_by_email=lambda _email: None,
+        save_email_by_username=_ignore,
+        get_timezone=lambda _telegram_id: 3,
+    )
+    repository = _module(
+        "source.db.repos.caldav_calendar",
+        delete_sent_event=_ignore,
+        get_sent_event_keys=_empty_keys,
+        save_event_send=_ignore,
+    )
+    app_logging = _module("source.app_logging", logger=FakeLogger())
+    telebot_types = _module(
+        "telebot.types",
+        InlineKeyboardMarkup=FakeInlineKeyboardMarkup,
+        InlineKeyboardButton=FakeInlineKeyboardButton,
+    )
+    telebot = _module("telebot", types=telebot_types)
+    caldav = _module("caldav", DAVClient=None, error=Exception)
+    icalendar = _module(
+        "icalendar",
+        Calendar=FakeCalendarParser,
+        vText=lambda value: value,
+    )
+
+    modules = {
+        "source.config": config,
+        "source.connections.sender": sender,
+        "source.db.repos.users": users,
+        "source.db.repos.caldav_calendar": repository,
+        "source.app_logging": app_logging,
+        "telebot": telebot,
+        "telebot.types": telebot_types,
+        "caldav": caldav,
+        "icalendar": icalendar,
+        "requests": ModuleType("requests"),
+    }
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    monkeypatch.delitem(sys.modules, "source.nc_calendar", raising=False)
+    module = importlib.import_module("source.nc_calendar")
+    yield module
+    sys.modules.pop("source.nc_calendar", None)
+
+
+def _key(
+    telegram_id: int = USER_ID,
+    cooldown: int = COOLDOWN,
+    event_uid: str = EVENT_UID,
+) -> SentEventKey:
+    return SentEventKey(
+        telegram_id=telegram_id,
+        cooldown_minutes=cooldown,
+        event_uid=event_uid,
+    )
+
+
+def _participant(
+    email: str = USER_EMAIL,
+    *,
+    status: str = "NEEDS-ACTION",
+) -> dict[str, object]:
+    return {
+        "email": email,
+        "name": email.split("@", maxsplit=1)[0],
+        "role": "ATTENDEE",
+        "status": status,
+    }
+
+
+def _run_poll_cycle(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    state: InMemoryNotificationState,
+    calendars: list[FakeCalendar],
+    now: FrozenDateTime,
+    identities: dict[str, int] | None = None,
+    cooldowns: list[int] | None = None,
+    sender: Mock | None = None,
+    mutator: Mock | None = None,
+) -> tuple[Mock, Mock]:
+    FrozenDateTime.current = now
+    principal = FakePrincipal(calendars)
+    sender = sender or Mock()
+    mutator = mutator or Mock()
+
+    def stop_polling(_seconds: int) -> None:
+        raise StopPolling
+
+    monkeypatch.setattr(nc_calendar, "datetime", FrozenDateTime)
+    monkeypatch.setattr(
+        nc_calendar,
+        "DAVClient",
+        lambda *_args, **_kwargs: FakeClient(principal),
+    )
+    monkeypatch.setattr(nc_calendar, "get_sent_event_keys", state.load)
+    monkeypatch.setattr(nc_calendar, "save_event_send", state.save)
+    monkeypatch.setattr(nc_calendar, "delete_sent_event", state.delete)
+    monkeypatch.setattr(
+        nc_calendar,
+        "get_tg_id_by_email",
+        (identities or {}).get,
+    )
+    monkeypatch.setattr(nc_calendar, "get_timezone", lambda _id: 3)
+    monkeypatch.setattr(
+        nc_calendar,
+        "format_to_timezone",
+        lambda _value, tz: "19:00",
+    )
+    monkeypatch.setattr(
+        nc_calendar,
+        "get_all_participants",
+        lambda component: component.participants,
+    )
+    monkeypatch.setattr(nc_calendar, "send_message_limited", sender)
+    monkeypatch.setattr(nc_calendar, "sleep", stop_polling)
+    monkeypatch.setattr(
+        nc_calendar,
+        "CALDAV_COOLDOWNS",
+        {"Team": cooldowns or [COOLDOWN]},
+    )
+    monkeypatch.setattr(
+        nc_calendar,
+        "set_all_attendees_needs_action",
+        mutator,
+        raising=False,
+    )
+
+    with pytest.raises(StopPolling):
+        nc_calendar.poll_events()
+
+    return sender, mutator
+
+
+def _weekly_event(
+    now: FrozenDateTime,
+    *,
+    event_uid: str = EVENT_UID,
+    email: str = USER_EMAIL,
+) -> FakeEvent:
+    return make_poll_event(
+        event_uid=event_uid,
+        summary="Team sync",
+        start=now + timedelta(minutes=30),
+        end=now + timedelta(minutes=90),
+        participants=[_participant(email)],
+    )
+
+
+def test_stale_cleanup_does_not_mutate_caldav(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = InMemoryNotificationState({_key()})
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    attendee = FakeAttendee(USER_EMAIL)
+    original_params = {
+        name: list(values) for name, values in attendee.params.items()
+    }
+    unrelated_event = make_poll_event(
+        event_uid="unrelated-event",
+        summary="Other event",
+        start=now + timedelta(minutes=30),
+        end=now + timedelta(minutes=90),
+        participants=[],
+        ical_attendees=attendee,
+    )
+    calendar = FakeCalendar([unrelated_event])
+    mutator = Mock()
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[calendar],
+        now=now,
+        mutator=mutator,
+    )
+
+    assert state.deleted == [_key()]
+    mutator.assert_not_called()
+    unrelated_event.save.assert_not_called()
+    assert attendee.params == original_params
+    assert calendar.expand_calls == [False]
+
+
+def test_stale_notification_is_deleted_from_local_state(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = _key()
+    state = InMemoryNotificationState({key})
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar()],
+        now=now,
+    )
+
+    assert state.keys == set()
+    assert state.deleted == [key]
+
+
+def test_observed_notification_is_not_deleted(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = _key()
+    state = InMemoryNotificationState({key})
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    event = _weekly_event(now)
+    sender = Mock()
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        identities={USER_EMAIL: USER_ID},
+        sender=sender,
+    )
+
+    assert state.keys == {key}
+    assert state.deleted == []
+    sender.assert_not_called()
+    event.save.assert_not_called()
+
+
+def test_incomplete_caldav_scan_preserves_local_state(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = _key()
+    state = InMemoryNotificationState({key})
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    mutator = Mock()
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[
+            FakeCalendar(),
+            FakeCalendar(error=RuntimeError("calendar unavailable")),
+        ],
+        now=now,
+        mutator=mutator,
+    )
+
+    assert state.keys == {key}
+    assert state.deleted == []
+    mutator.assert_not_called()
+
+
+def test_cleanup_deletes_only_stale_user_record(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stale_key = _key(telegram_id=101)
+    newly_sent_key = _key(telegram_id=202)
+    other_cooldown_key = _key(telegram_id=202, cooldown=15)
+    state = InMemoryNotificationState({stale_key, other_cooldown_key})
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    event = _weekly_event(now, email="second@example.com")
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        identities={"second@example.com": 202},
+        cooldowns=[COOLDOWN, 15],
+    )
+
+    assert state.deleted == [stale_key]
+    assert state.saved == [newly_sent_key]
+    assert state.keys == {newly_sent_key, other_cooldown_key}
+
+
+def test_event_uid_with_underscores_is_not_truncated(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = _key(event_uid="team_sync_2026_instance")
+    state = InMemoryNotificationState({key})
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar()],
+        now=now,
+    )
+
+    assert state.deleted == [key]
+    assert state.deleted[0].event_uid == "team_sync_2026_instance"
+
+
+def test_next_weekly_occurrence_can_be_notified_after_cleanup(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = InMemoryNotificationState()
+    sender = Mock()
+    mutator = Mock()
+    first_week = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    first_event = _weekly_event(first_week)
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([first_event])],
+        now=first_week,
+        identities={USER_EMAIL: USER_ID},
+        sender=sender,
+        mutator=mutator,
+    )
+
+    assert sender.call_count == 1
+    assert state.saved == [_key()]
+    assert state.deleted == []
+    assert state.keys == {_key()}
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar()],
+        now=first_week + timedelta(days=1),
+        sender=sender,
+        mutator=mutator,
+    )
+
+    assert sender.call_count == 1
+    assert state.saved == [_key()]
+    assert state.deleted == [_key()]
+    assert state.keys == set()
+
+    second_week = first_week + timedelta(days=7)
+    second_event = _weekly_event(second_week)
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([second_event])],
+        now=second_week,
+        identities={USER_EMAIL: USER_ID},
+        sender=sender,
+        mutator=mutator,
+    )
+
+    assert sender.call_count == 2
+    assert state.saved == [_key(), _key()]
+    assert state.deleted == [_key()]
+    assert state.keys == {_key()}
+    mutator.assert_not_called()
+    first_event.save.assert_not_called()
+    second_event.save.assert_not_called()
+
+
+def test_explicit_partstat_update_still_saves_event(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    FrozenDateTime.current = now
+    attendee = FakeAttendee(USER_EMAIL)
+    component = FakeComponent(
+        {
+            "UID": EVENT_UID,
+            "ATTENDEE": attendee,
+        }
+    )
+    event = FakeEvent(FakeICalendar([component]))
+    calendar = FakeCalendar([event])
+    principal = FakePrincipal([calendar])
+
+    monkeypatch.setattr(nc_calendar, "datetime", FrozenDateTime)
+    monkeypatch.setattr(
+        nc_calendar,
+        "DAVClient",
+        lambda *_args, **_kwargs: FakeClient(principal),
+    )
+
+    result = nc_calendar.update_event_partstat(
+        EVENT_UID,
+        USER_EMAIL,
+        "accepted",
+    )
+
+    assert result is True
+    assert attendee.params["PARTSTAT"] == ["ACCEPTED"]
+    assert attendee.params["RSVP"] == ["FALSE"]
+    event.save.assert_called_once_with()
+    assert calendar.expand_calls == [True]
+
+
+def test_periodic_poller_has_no_caldav_write_calls(
+    nc_calendar: ModuleType,
+) -> None:
+    source = textwrap.dedent(inspect.getsource(nc_calendar.poll_events))
+    tree = ast.parse(source)
+    called_names = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    called_attributes = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+
+    assert "set_all_attendees_needs_action" not in called_names
+    assert called_attributes.isdisjoint({"put", "save"})

--- a/tests/test_caldav_polling.py
+++ b/tests/test_caldav_polling.py
@@ -155,11 +155,13 @@ def _run_poll_cycle(
     cooldowns: list[int] | None = None,
     sender: Mock | None = None,
     mutator: Mock | None = None,
+    timezone_getter: Mock | None = None,
 ) -> tuple[Mock, Mock]:
     FrozenDateTime.current = now
     principal = FakePrincipal(calendars)
     sender = sender or Mock()
     mutator = mutator or Mock()
+    timezone_getter = timezone_getter or Mock(return_value=3)
 
     def stop_polling(_seconds: int) -> None:
         raise StopPolling
@@ -178,7 +180,7 @@ def _run_poll_cycle(
         "get_tg_id_by_email",
         (identities or {}).get,
     )
-    monkeypatch.setattr(nc_calendar, "get_timezone", lambda _id: 3)
+    monkeypatch.setattr(nc_calendar, "get_timezone", timezone_getter)
     monkeypatch.setattr(
         nc_calendar,
         "format_to_timezone",
@@ -308,6 +310,7 @@ def test_observed_notification_is_not_deleted(
     )
     event = _weekly_event(now)
     sender = Mock()
+    timezone_getter = Mock(return_value=3)
 
     _run_poll_cycle(
         nc_calendar,
@@ -317,11 +320,46 @@ def test_observed_notification_is_not_deleted(
         now=now,
         identities={USER_EMAIL: USER_ID},
         sender=sender,
+        timezone_getter=timezone_getter,
     )
 
     assert state.keys == {key}
     assert state.deleted == []
     sender.assert_not_called()
+    timezone_getter.assert_not_called()
+    event.save.assert_not_called()
+
+
+def test_participant_without_telegram_id_is_skipped(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = InMemoryNotificationState()
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    event = _weekly_event(now, email="unknown@example.com")
+    sender = Mock()
+    timezone_getter = Mock(return_value=3)
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        sender=sender,
+        timezone_getter=timezone_getter,
+    )
+
+    assert state.keys == set()
+    assert state.saved == []
+    sender.assert_not_called()
+    timezone_getter.assert_not_called()
     event.save.assert_not_called()
 
 

--- a/tests/test_caldav_repository.py
+++ b/tests/test_caldav_repository.py
@@ -1,0 +1,118 @@
+import importlib.util
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from source.caldav_notification_state import SentEventKey
+
+
+@dataclass(frozen=True)
+class Condition:
+    field_name: str
+    value: object
+
+
+class Field:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __eq__(self, value: object) -> Condition:
+        return Condition(self.name, value)
+
+
+class Statement:
+    def __init__(self, operation: str) -> None:
+        self.operation = operation
+        self.conditions: tuple[Condition, ...] = ()
+
+    def where(self, *conditions: Condition) -> "Statement":
+        self.conditions = conditions
+        return self
+
+
+class FakeCalDavSendData:
+    tg_id = Field("tg_id")
+    cooldown = Field("cooldown")
+    event_name = Field("event_name")
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.executed: list[Statement] = []
+
+    def execute(self, statement: Statement) -> None:
+        self.executed.append(statement)
+
+
+@pytest.fixture
+def repository_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[ModuleType, FakeSession]:
+    session = FakeSession()
+
+    @contextmanager
+    def get_session() -> Iterator[FakeSession]:
+        yield session
+
+    sqlalchemy = ModuleType("sqlalchemy")
+    sqlalchemy.delete = lambda model: Statement("delete")
+    sqlalchemy.select = lambda *fields: Statement("select")
+
+    db_module = ModuleType("source.db.db")
+    db_module.get_session = get_session
+
+    models_module = ModuleType("source.migrations.models")
+    models_module.CalDavSendData = FakeCalDavSendData
+
+    monkeypatch.setitem(sys.modules, "sqlalchemy", sqlalchemy)
+    monkeypatch.setitem(sys.modules, "source.db.db", db_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "source.migrations.models",
+        models_module,
+    )
+
+    module_path = (
+        Path(__file__).parents[1]
+        / "source"
+        / "db"
+        / "repos"
+        / "caldav_calendar.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "caldav_repository_under_test",
+        module_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return module, session
+
+
+def test_delete_sent_event_uses_exact_composite_key(
+    repository_module: tuple[ModuleType, FakeSession],
+) -> None:
+    repository, session = repository_module
+    key = SentEventKey(
+        telegram_id=101,
+        cooldown_minutes=60,
+        event_uid="team_sync_2026_instance",
+    )
+
+    repository.delete_sent_event(key)
+
+    assert len(session.executed) == 1
+    statement = session.executed[0]
+    assert statement.operation == "delete"
+    assert statement.conditions == (
+        Condition("tg_id", 101),
+        Condition("cooldown", 60),
+        Condition("event_name", "team_sync_2026_instance"),
+    )

--- a/tests/test_test_setup.py
+++ b/tests/test_test_setup.py
@@ -1,0 +1,10 @@
+import sys
+from importlib.util import find_spec
+
+
+def test_supported_python_runtime() -> None:
+    assert sys.version_info >= (3, 11)
+
+
+def test_source_package_is_discoverable() -> None:
+    assert find_spec("source") is not None


### PR DESCRIPTION
## Проблема

После завершения экземпляра повторяющегося события CalDAV poller
принимал его отсутствие в 24-часовом окне за удаление и сбрасывал
PARTSTAT всех участников. Сохранение expanded occurrence создавало
изменение события с UTC-временем и вызывало Nextcloud hook.

## Причина

Очистка локального состояния уведомлений была связана с записью
в удалённый календарь.

## Решение

- periodic cleanup теперь изменяет только локальное состояние;
- удаление выполняется по точному ключу пользователя, cooldown и UID;
- неполный CalDAV scan не запускает cleanup;
- CalDAV write оставлен только для явных пользовательских действий;
- добавлены regression unit-тесты;
- Ruff и unit-тесты сделаны блокирующими в CI на Python 3.11 и 3.12.

## Проверка

- `ruff check source/caldav_notification_state.py source/db/repos/caldav_calendar.py tests`
- `ruff format --check source/caldav_notification_state.py source/db/repos/caldav_calendar.py tests`
- `pytest -q` — 14 passed, 100% branch coverage нового state-модуля
- weekly recurring regression scenario
- explicit PARTSTAT update scenario

## Не входит в PR

- очистка уже созданных UTC recurrence exceptions;
- переработка пользовательских timezone;
- массовое форматирование legacy-кода.