### PR TITLE
fix(calendar): respect recipient timezone and floating time

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           ruff check . --select E9,F63,F7,F82
           ruff check \
+            source/calendar_time.py \
             source/caldav_notification_state.py \
             source/db/repos/caldav_calendar.py \
             source/timezone.py \
@@ -56,6 +57,7 @@ jobs:
       - name: Check Ruff formatting
         run: |
           ruff format --check \
+            source/calendar_time.py \
             source/caldav_notification_state.py \
             source/db/repos/caldav_calendar.py \
             source/timezone.py \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,9 +39,18 @@ jobs:
 
       - name: Run Ruff linter
         run: |
+          ruff check . --select E9,F63,F7,F82
           ruff check \
             source/caldav_notification_state.py \
             source/db/repos/caldav_calendar.py \
+            source/timezone.py \
+            source/timezone_command.py \
+            source/datetime_formatting.py \
+            source/db/repos/users.py \
+            source/migrations/init_db.py \
+            source/migrations/migration.py \
+            alembic/env.py \
+            alembic/versions/0001_add_user_timezones.py \
             tests
 
       - name: Check Ruff formatting
@@ -49,6 +58,14 @@ jobs:
           ruff format --check \
             source/caldav_notification_state.py \
             source/db/repos/caldav_calendar.py \
+            source/timezone.py \
+            source/timezone_command.py \
+            source/datetime_formatting.py \
+            source/db/repos/users.py \
+            source/migrations/init_db.py \
+            source/migrations/migration.py \
+            alembic/env.py \
+            alembic/versions/0001_add_user_timezones.py \
             tests
 
       - name: Run unit tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,32 +11,48 @@ permissions:
 
 jobs:
   test:
+    name: Quality (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
             source/requirements.txt
+            requirements-dev.txt
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
-          pip install -r source/requirements.txt
+          python -m pip install \
+            -r source/requirements.txt \
+            -r requirements-dev.txt
 
-      - name: Run linter - hard errors only
+      - name: Run Ruff linter
         run: |
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          ruff check \
+            source/caldav_notification_state.py \
+            source/db/repos/caldav_calendar.py \
+            tests
 
-      - name: Run linter - soft style guide
+      - name: Check Ruff formatting
         run: |
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics
+          ruff format --check \
+            source/caldav_notification_state.py \
+            source/db/repos/caldav_calendar.py \
+            tests
+
+      - name: Run unit tests
+        run: pytest -q
 
   build-and-push:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ source/db/__pycache__/
 source/db/repos/__pycache__/
 source/migrations/__pycache__/
 alembic
+__pycache__/
+.coverage
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 .env
+.coverage
+.pytest_cache/
+.ruff_cache/
+.venv/
+__pycache__/
 bot.log
 logs/bot.log
 .idea
@@ -9,7 +14,5 @@ source/connections/__pycache__
 source/db/__pycache__/
 source/db/repos/__pycache__/
 source/migrations/__pycache__/
-alembic
-__pycache__/
-.coverage
-.pytest_cache/
+alembic/__pycache__/
+alembic/versions/__pycache__/

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,26 +1,13 @@
-from logging.config import fileConfig
-
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import Connection
 
 from alembic import context
+from source.migrations.models import Base
 
-import os
-from dotenv import load_dotenv
-
-load_dotenv()
-
-from source.db.db import Base
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
 
-'''
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
-if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
-'''
 # add your model's MetaData object here
 # for 'autogenerate' support
 # from myapp import mymodel
@@ -64,6 +51,11 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
+    supplied_connection = config.attributes.get("connection")
+    if supplied_connection is not None:
+        _run_migrations(supplied_connection)
+        return
+
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
@@ -71,14 +63,19 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(
-            connection=connection, target_metadata=target_metadata, compare_type=True,
-            compare_server_default=True
-        )
+        _run_migrations(connection)
 
-        with context.begin_transaction():
-            context.run_migrations()
 
+def _run_migrations(connection: Connection) -> None:
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        compare_type=True,
+        compare_server_default=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
 
 
 if context.is_offline_mode():

--- a/alembic/versions/0001_add_user_timezones.py
+++ b/alembic/versions/0001_add_user_timezones.py
@@ -1,0 +1,110 @@
+"""Add Nextcloud and override timezone fields.
+
+Revision ID: 0001_user_timezones
+Revises:
+Create Date: 2026-08-11
+"""
+
+from collections.abc import Iterable
+
+import sqlalchemy as sa
+from sqlalchemy.engine import Connection
+
+from alembic import op
+
+revision = "0001_user_timezones"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def _column_names(connection: Connection) -> set[str]:
+    inspector = sa.inspect(connection)
+    if not inspector.has_table("users"):
+        return set()
+    return {column["name"] for column in inspector.get_columns("users")}
+
+
+def _legacy_offset_to_tzid(value: object) -> str | None:
+    if not isinstance(value, int) or isinstance(value, bool):
+        return None
+    if value == 3 or not -12 <= value <= 14:
+        return None
+    if value == 0:
+        return "Etc/UTC"
+    if value > 0:
+        return f"Etc/GMT-{value}"
+    return f"Etc/GMT+{abs(value)}"
+
+
+def _legacy_users(connection: Connection) -> Iterable[sa.RowMapping]:
+    result = connection.execute(
+        sa.text("SELECT tg_id, nc_time_zone, timezone_override FROM users")
+    )
+    return result.mappings()
+
+
+def _backfill_legacy_offsets(connection: Connection) -> None:
+    for user in _legacy_users(connection):
+        if user["timezone_override"] is not None:
+            continue
+        tzid = _legacy_offset_to_tzid(user["nc_time_zone"])
+        if tzid is None:
+            continue
+        connection.execute(
+            sa.text(
+                "UPDATE users SET timezone_override = :tzid "
+                "WHERE tg_id = :tg_id AND timezone_override IS NULL"
+            ),
+            {"tg_id": user["tg_id"], "tzid": tzid},
+        )
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    columns = _column_names(connection)
+    if not columns:
+        return
+
+    with op.batch_alter_table("users") as batch_op:
+        if "nc_email" not in columns:
+            batch_op.add_column(
+                sa.Column("nc_email", sa.String(255), nullable=True)
+            )
+        if "nc_time_zone" not in columns:
+            batch_op.add_column(
+                sa.Column(
+                    "nc_time_zone",
+                    sa.Integer(),
+                    nullable=False,
+                    server_default=sa.text("3"),
+                )
+            )
+        if "nc_timezone" not in columns:
+            batch_op.add_column(
+                sa.Column("nc_timezone", sa.String(64), nullable=True)
+            )
+        if "timezone_override" not in columns:
+            batch_op.add_column(
+                sa.Column("timezone_override", sa.String(64), nullable=True)
+            )
+        if "nc_token" not in columns:
+            batch_op.add_column(
+                sa.Column("nc_token", sa.String(100), nullable=True)
+            )
+
+    if "nc_time_zone" in columns:
+        _backfill_legacy_offsets(connection)
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    columns = _column_names(connection)
+    if not columns:
+        return
+
+    with op.batch_alter_table("users") as batch_op:
+        if "timezone_override" in columns:
+            batch_op.drop_column("timezone_override")
+        if "nc_timezone" in columns:
+            batch_op.drop_column("nc_timezone")

--- a/init.sql
+++ b/init.sql
@@ -2,8 +2,13 @@ CREATE DATABASE IF NOT EXISTS itmocraft_tg_bot CHARACTER SET utf8mb4 COLLATE utf
 USE itmocraft_tg_bot;
 
 CREATE TABLE IF NOT EXISTS users (
-  tg_id     BIGINT        NOT NULL PRIMARY KEY,
-  nc_login  VARCHAR(100)  NOT NULL
+  tg_id              BIGINT        NOT NULL PRIMARY KEY,
+  nc_login           VARCHAR(100)  NOT NULL,
+  nc_email           VARCHAR(255)  NULL,
+  nc_time_zone       INT           NOT NULL DEFAULT 3,
+  nc_timezone        VARCHAR(64)   NULL,
+  timezone_override  VARCHAR(64)   NULL,
+  nc_token           VARCHAR(100)  NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS tasks (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[tool.ruff]
+target-version = "py311"
+line-length = 79
+indent-width = 4
+
+[tool.ruff.lint]
+select = [
+    "E4",
+    "E7",
+    "E9",
+    "E501",
+    "F",
+    "I",
+    "B",
+    "C4",
+    "SIM",
+    "UP",
+    "RUF",
+    "PT",
+    "W505",
+]
+
+[tool.ruff.lint.pycodestyle]
+max-doc-length = 72
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"
+
+[tool.pytest.ini_options]
+minversion = "9.1"
+testpaths = ["tests"]
+addopts = [
+    "--strict-config",
+    "--strict-markers",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,12 @@ line-ending = "auto"
 [tool.pytest.ini_options]
 minversion = "9.1"
 testpaths = ["tests"]
+pythonpath = ["."]
 addopts = [
     "--strict-config",
     "--strict-markers",
     "--cov=source.caldav_notification_state",
+    "--cov=source.timezone",
     "--cov-branch",
     "--cov-report=term-missing",
     "--cov-fail-under=100",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,4 +34,8 @@ testpaths = ["tests"]
 addopts = [
     "--strict-config",
     "--strict-markers",
+    "--cov=source.caldav_notification_state",
+    "--cov-branch",
+    "--cov-report=term-missing",
+    "--cov-fail-under=100",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ pythonpath = ["."]
 addopts = [
     "--strict-config",
     "--strict-markers",
+    "--cov=source.calendar_time",
     "--cov=source.caldav_notification_state",
     "--cov=source.timezone",
     "--cov-branch",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest==9.1.1
+pytest-cov==7.1.0
+ruff==0.16.2

--- a/source/app.py
+++ b/source/app.py
@@ -133,6 +133,10 @@ def _notify_startup():
 
 
 def run():
+    logger.info("Инициализация и миграция базы данных.")
+    init_db()
+    auto_migrate()
+
     if is_debug():
         try:
             info = bot.get_webhook_info()
@@ -155,11 +159,6 @@ def run():
     threading.Thread(target=sync_nextcloud_users, daemon=True).start()
     if is_debug():
         bot.set_update_listener(_updates_listener)
-
-    # migrations
-    logger.info(f"Миграция базы данных.")
-    init_db()
-    auto_migrate()
 
     backoff = 5.0
     while True:

--- a/source/caldav_notification_state.py
+++ b/source/caldav_notification_state.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class SentEventKey:
+    telegram_id: int
+    cooldown_minutes: int
+    event_uid: str
+
+
+def find_stale_keys(
+    saved_keys: set[SentEventKey],
+    observed_keys: set[SentEventKey],
+    *,
+    scan_complete: bool,
+) -> set[SentEventKey]:
+    if not scan_complete:
+        return set()
+
+    return saved_keys - observed_keys

--- a/source/calendar_time.py
+++ b/source/calendar_time.py
@@ -1,0 +1,64 @@
+"""RFC 5545 localization helpers for iCalendar temporal values."""
+
+from datetime import UTC, date, datetime, time, timedelta, tzinfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+class UnknownSourceTimezoneError(ValueError):
+    """Raised when an iCalendar property declares an unknown TZID."""
+
+    def __init__(self, tzid: str) -> None:
+        self.tzid = tzid
+        super().__init__(f"Unknown iCalendar source timezone: {tzid}")
+
+
+def localize_ical_value(
+    value: datetime | date,
+    *,
+    target_timezone: tzinfo,
+    source_tzid: str | None,
+) -> datetime | date:
+    """Localize one iCalendar DATE or DATE-TIME without guessing."""
+    if not isinstance(value, datetime):
+        return value
+
+    if value.tzinfo is not None:
+        return value.astimezone(UTC).astimezone(target_timezone)
+
+    if source_tzid is None:
+        return value.replace(tzinfo=target_timezone, fold=0)
+
+    try:
+        source_timezone = ZoneInfo(source_tzid)
+    except (OSError, ValueError, ZoneInfoNotFoundError) as error:
+        raise UnknownSourceTimezoneError(source_tzid) from error
+
+    source_value = value.replace(tzinfo=source_timezone, fold=0)
+    return source_value.astimezone(UTC).astimezone(target_timezone)
+
+
+def local_day_window(
+    now_utc: datetime,
+    target_timezone: tzinfo,
+) -> tuple[datetime, datetime]:
+    """Return recipient-local midnight bounds for the current day."""
+    local_date = now_utc.astimezone(target_timezone).date()
+    start = datetime.combine(local_date, time.min, target_timezone)
+    end = datetime.combine(
+        local_date + timedelta(days=1),
+        time.min,
+        target_timezone,
+    )
+    return start, end
+
+
+def local_week_window(
+    now_utc: datetime,
+    target_timezone: tzinfo,
+) -> tuple[datetime, datetime]:
+    """Return seven recipient-local calendar days."""
+    local_date = now_utc.astimezone(target_timezone).date()
+    start = datetime.combine(local_date, time.min, target_timezone)
+    end_date = local_date + timedelta(days=7)
+    end = datetime.combine(end_date, time.min, target_timezone)
+    return start, end

--- a/source/callbacks.py
+++ b/source/callbacks.py
@@ -2,11 +2,53 @@ import requests
 from requests.auth import HTTPBasicAuth
 from telebot.types import InlineKeyboardMarkup, InlineKeyboardButton
 from source.connections.bot_factory import bot
-from source.db.repos.users import delete_login_token, get_token, save_login_to_db_with_token, get_email_by_tg_id
+from source.db.repos.users import (
+    NEXTCLOUD_FIELD_MISSING,
+    get_email_by_tg_id,
+    get_token,
+    save_login_profile,
+)
 from source.config import BASE_URL, USERNAME, PASSWORD, HEADERS, WEB_APP_URL
 from source.connections.sender import send_message_limited, edit_message_limited
 from source.nc_calendar import update_event_partstat, msg_design_from_button
 from source.db.repos.caldav_calendar import get_name_by_id
+
+
+def complete_login_flow_profile(
+    tg_id: int,
+    auth_data: dict,
+    *,
+    base_url: str = WEB_APP_URL,
+    request_get=requests.get,
+    save_profile=save_login_profile,
+) -> str:
+    """Fetch and atomically persist the authenticated self profile."""
+    login_name = auth_data["loginName"]
+    app_password = auth_data["appPassword"]
+    headers = {
+        "OCS-APIRequest": "true",
+        "Accept": "application/json",
+    }
+    response = request_get(
+        base_url + "/ocs/v2.php/cloud/user",
+        auth=(login_name, app_password),
+        headers=headers,
+    )
+    response.raise_for_status()
+
+    user_data = response.json()["ocs"]["data"]
+    profile_login = user_data["id"]
+    save_profile(
+        tg_id,
+        profile_login,
+        user_data.get("email"),
+        app_password,
+        timezone_value=user_data.get(
+            "timezone",
+            NEXTCLOUD_FIELD_MISSING,
+        ),
+    )
+    return profile_login
 
 @bot.callback_query_handler(func=lambda call: call.data.startswith("move:"))
 def handle_card_move(call):
@@ -66,29 +108,10 @@ def check_login(call):
             bot.answer_callback_query(call.id, "Вы еще не подтвердили вход в браузере!", show_alert=True)
         elif response.status_code == 200:
             auth_data = response.json()
-            nc_login = auth_data['loginName']
-            nc_token = auth_data['appPassword']
-            headers_get_info = {
-                'OCS-APIRequest': 'true',
-                'Accept': 'application/json'
-            }
-            delete_login_token(call.from_user.id)
-
-
-            user_url = WEB_APP_URL + "/ocs/v2.php/cloud/user"
-
-            user_response = requests.get(
-                user_url,
-                auth=(nc_login, nc_token),
-                headers=headers_get_info
+            nc_login = complete_login_flow_profile(
+                call.from_user.id,
+                auth_data,
             )
-
-            user_response.raise_for_status()
-
-            data = user_response.json()
-            email = data.get("ocs", {}).get("data", {}).get("email")
-            nc_login = data.get("ocs", {}).get("data", {}).get("id")
-            save_login_to_db_with_token(call.from_user.id, nc_login, email, nc_token)
             bot.edit_message_text(f"✅ Успешно! Аккаунт {nc_login} привязан.",
                                   call.message.chat.id,
                                   call.message.message_id)

--- a/source/config.py
+++ b/source/config.py
@@ -1,7 +1,6 @@
 import os
 from dotenv import load_dotenv
 import subprocess
-from datetime import timezone, timedelta
 
 load_dotenv()
 
@@ -100,8 +99,3 @@ for key, value in os.environ.items():
 UPDATE_INTERVAL = int(os.getenv("UPDATE_INTERVAL", "1"))
 
 BUFF_SIZE = int(os.getenv("BUFF_SIZE", "128"))
-
-TIMEZONES = {
-    i: timezone(timedelta(hours=i))
-    for i in range(-12, 15)
-}

--- a/source/datetime_formatting.py
+++ b/source/datetime_formatting.py
@@ -19,13 +19,9 @@ def format_datetime(
     return value.astimezone(target_timezone).strftime(date_format)
 
 
-def format_calendar_time(value: datetime, target_timezone: tzinfo) -> str:
-    """Format a CalDAV datetime as local hours and minutes."""
-    return format_datetime(
-        value,
-        target_timezone,
-        date_format="%H:%M",
-    )
+def format_calendar_time(value: datetime) -> str:
+    """Format an already-localized CalDAV date and time."""
+    return value.strftime("%Y-%m-%d %H:%M")
 
 
 def format_task_due_date(value: datetime, target_timezone: tzinfo) -> str:

--- a/source/datetime_formatting.py
+++ b/source/datetime_formatting.py
@@ -1,0 +1,37 @@
+"""Timezone-safe formatting for calendar and task datetimes."""
+
+from datetime import UTC, datetime, tzinfo
+
+
+def format_datetime(
+    value: datetime,
+    target_timezone: tzinfo,
+    *,
+    date_format: str,
+) -> str:
+    """Format an instant in a timezone, treating naive input as UTC."""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+
+    if not isinstance(target_timezone, tzinfo):
+        target_timezone = UTC
+
+    return value.astimezone(target_timezone).strftime(date_format)
+
+
+def format_calendar_time(value: datetime, target_timezone: tzinfo) -> str:
+    """Format a CalDAV datetime as local hours and minutes."""
+    return format_datetime(
+        value,
+        target_timezone,
+        date_format="%H:%M",
+    )
+
+
+def format_task_due_date(value: datetime, target_timezone: tzinfo) -> str:
+    """Format a Deck due instant in a user's local timezone."""
+    return format_datetime(
+        value,
+        target_timezone,
+        date_format="%y-%m-%d %H:%M",
+    )

--- a/source/db/repos/caldav_calendar.py
+++ b/source/db/repos/caldav_calendar.py
@@ -1,54 +1,83 @@
-from typing import Optional, Set
+from sqlalchemy import delete, select
 
-from sqlalchemy import select, delete
-
+from source.caldav_notification_state import SentEventKey
 from source.db.db import get_session
 from source.migrations.models import CalDavSendData
 
 
-def get_events_from_db() -> Set[str]:
-    """Возвращает set строк в формате {tg_id}_{cooldown}_{event_name} из БД."""
+def get_sent_event_keys() -> set[SentEventKey]:
+    """Return the notification keys currently stored in the database."""
     with get_session() as session:
-        stmt = select(CalDavSendData.tg_id, CalDavSendData.cooldown, CalDavSendData.event_name)
-        result = session.execute(stmt).all()
-        return {f"{row.tg_id}_{row.cooldown}_{row.event_name}" for row in result}
+        stmt = select(
+            CalDavSendData.tg_id,
+            CalDavSendData.cooldown,
+            CalDavSendData.event_name,
+        )
+        rows = session.execute(stmt).all()
+        return {
+            SentEventKey(
+                telegram_id=row.tg_id,
+                cooldown_minutes=row.cooldown,
+                event_uid=row.event_name,
+            )
+            for row in rows
+        }
 
 
-def get_url_by_id(t_id: int) -> Optional[str]:
+def get_url_by_id(t_id: int) -> str | None:
     """Возвращает URL события по ID."""
     with get_session() as session:
         event = session.get(CalDavSendData, t_id)
         return event.url if event else None
 
 
-def get_name_by_id(t_id: int) -> Optional[str]:
+def get_name_by_id(t_id: int) -> str | None:
     """Возвращает event_name по ID."""
     with get_session() as session:
         event = session.get(CalDavSendData, t_id)
         return event.event_name if event else None
 
 
-def get_id_by_name(name: str) -> Optional[int]:
+def get_id_by_name(name: str) -> int | None:
     """Возвращает ID события по event_name."""
     with get_session() as session:
-        stmt = select(CalDavSendData).where(CalDavSendData.event_name == name)
+        stmt = select(CalDavSendData).where(
+            CalDavSendData.event_name == name,
+        )
         event = session.execute(stmt).scalar_one_or_none()
         return event.id if event else None
 
 
-def save_event_sends(name: str, tg_id: int, cooldown: int, event_name: str, url: str) -> None:
+def save_event_send(
+    name: str,
+    key: SentEventKey,
+    url: str,
+) -> None:
     """Сохраняет новое событие (игнорирует дубликаты)."""
     with get_session() as session:
-        # Проверяем существование
-        stmt = select(CalDavSendData).where(CalDavSendData.event_name == event_name, CalDavSendData.tg_id == tg_id, CalDavSendData.cooldown == cooldown)
+        stmt = select(CalDavSendData).where(
+            CalDavSendData.event_name == key.event_uid,
+            CalDavSendData.tg_id == key.telegram_id,
+            CalDavSendData.cooldown == key.cooldown_minutes,
+        )
         existing = session.execute(stmt).scalar_one_or_none()
         if not existing:
-            event = CalDavSendData(name=name, tg_id=tg_id, cooldown=cooldown, event_name=event_name, url=url)
+            event = CalDavSendData(
+                name=name,
+                tg_id=key.telegram_id,
+                cooldown=key.cooldown_minutes,
+                event_name=key.event_uid,
+                url=url,
+            )
             session.add(event)
 
 
-def delete_event_sends(name: str) -> None:
-    """Удаляет событие по event_name."""
+def delete_sent_event(key: SentEventKey) -> None:
+    """Delete one exact notification record."""
     with get_session() as session:
-        stmt = delete(CalDavSendData).where(CalDavSendData.event_name == name)
+        stmt = delete(CalDavSendData).where(
+            CalDavSendData.tg_id == key.telegram_id,
+            CalDavSendData.cooldown == key.cooldown_minutes,
+            CalDavSendData.event_name == key.event_uid,
+        )
         session.execute(stmt)

--- a/source/db/repos/caldav_calendar.py
+++ b/source/db/repos/caldav_calendar.py
@@ -6,7 +6,7 @@ from source.migrations.models import CalDavSendData
 
 
 def get_sent_event_keys() -> set[SentEventKey]:
-    """Return the notification keys currently stored in the database."""
+    """Возвращает ключи отправленных уведомлений из базы данных."""
     with get_session() as session:
         stmt = select(
             CalDavSendData.tg_id,
@@ -73,7 +73,7 @@ def save_event_send(
 
 
 def delete_sent_event(key: SentEventKey) -> None:
-    """Delete one exact notification record."""
+    """Удаляет точную запись отправленного уведомления."""
     with get_session() as session:
         stmt = delete(CalDavSendData).where(
             CalDavSendData.tg_id == key.telegram_id,

--- a/source/db/repos/users.py
+++ b/source/db/repos/users.py
@@ -1,143 +1,264 @@
-from typing import Optional, Dict, List, Tuple
+from datetime import tzinfo
 
-from sqlalchemy import select, delete
+from sqlalchemy import delete, select
 
+from source.app_logging import logger
 from source.db.db import get_session
-from source.migrations.models import User
+from source.migrations.models import NextCloudLogin, User
+from source.timezone import (
+    TimezoneSettings,
+    normalize_tzid,
+    resolve_effective_timezone,
+)
+
+NEXTCLOUD_FIELD_MISSING = object()
 
 
-def get_login_by_tg_id(tg_id: int) -> Optional[str]:
-    """Возвращает Nextcloud-логин пользователя по Telegram ID."""
+class UserNotFoundError(LookupError):
+    """Raised when a Telegram user has no linked Nextcloud profile."""
+
+
+def _normalize_email(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _apply_nextcloud_timezone(user: User, value: object) -> None:
+    if value is NEXTCLOUD_FIELD_MISSING:
+        return
+
+    normalized = normalize_tzid(value)
+    if normalized is not None:
+        user.nc_timezone = normalized
+        return
+
+    if value is None or (isinstance(value, str) and not value.strip()):
+        user.nc_timezone = None
+        return
+
+    logger.warning(
+        "NEXTCLOUD: ignoring invalid timezone for user %s",
+        user.nc_login,
+    )
+
+
+def get_login_by_tg_id(tg_id: int) -> str | None:
+    """Return a Nextcloud login for a Telegram user."""
     with get_session() as session:
         user = session.get(User, tg_id)
         return user.nc_login if user else None
 
 
-def get_email_by_tg_id(tg_id: int) -> Optional[str]:
-    """Возвращает email пользователя по Telegram ID."""
+def get_email_by_tg_id(tg_id: int) -> str | None:
+    """Return a Nextcloud email for a Telegram user."""
     with get_session() as session:
         user = session.get(User, tg_id)
         return user.nc_email if user else None
 
 
-def get_tg_id_by_email(email: str) -> Optional[int]:
-    """Возвращает Telegram ID по email."""
+def get_tg_id_by_email(email: str) -> int | None:
+    """Return a Telegram ID for a Nextcloud email."""
     with get_session() as session:
         stmt = select(User).where(User.nc_email == email)
         user = session.execute(stmt).scalar_one_or_none()
         return user.tg_id if user else None
 
 
-def get_user_credentials_from_db(email: str) -> Optional[Tuple[str, str]]:
-    """Возвращает (nc_login, nc_token) по email."""
+def get_user_credentials_from_db(email: str) -> tuple[str, str] | None:
+    """Return a user's Nextcloud login and app password."""
     with get_session() as session:
         stmt = select(User).where(User.nc_email == email)
         user = session.execute(stmt).scalar_one_or_none()
-        return (user.nc_login, user.nc_token) if user else None
+        if user is None or user.nc_token is None:
+            return None
+        return user.nc_login, user.nc_token
 
 
 def save_login_to_db(tg_id: int, nc_login: str) -> None:
-    """Сохраняет или обновляет соответствие Telegram ID и Nextcloud логина."""
+    """Save or update a Telegram-to-Nextcloud login mapping."""
     with get_session() as session:
         user = session.get(User, tg_id)
         if user:
             user.nc_login = nc_login
         else:
+            session.add(User(tg_id=tg_id, nc_login=nc_login))
+
+
+def save_login_profile(
+    tg_id: int,
+    nc_login: str,
+    email: object,
+    nc_token: str,
+    *,
+    timezone_value: object = NEXTCLOUD_FIELD_MISSING,
+) -> None:
+    """Atomically save Login Flow credentials and profile fields."""
+    with get_session() as session:
+        user = session.get(User, tg_id)
+        if user is None:
             user = User(tg_id=tg_id, nc_login=nc_login)
             session.add(user)
 
-
-def save_login_to_db_with_token(tg_id: int, nc_login: str, email: str, nc_token: str) -> None:
-    """Сохраняет или обновляет пользователя с токеном."""
-    with get_session() as session:
-        user = session.get(User, tg_id)
-        if user:
-            user.nc_login = nc_login
-            user.nc_email = email
-            user.nc_token = nc_token
-        else:
-            user = User(tg_id=tg_id, nc_login=nc_login, nc_email=email, nc_token=nc_token)
-            session.add(user)
+        user.nc_login = nc_login
+        user.nc_email = _normalize_email(email)
+        user.nc_token = nc_token
+        _apply_nextcloud_timezone(user, timezone_value)
+        session.execute(
+            delete(NextCloudLogin).where(NextCloudLogin.tg_id == tg_id)
+        )
 
 
-def save_email_by_username(nc_email: str, nc_login: str) -> None:
-    """Обновляет email пользователя по логину."""
+def save_login_to_db_with_token(
+    tg_id: int,
+    nc_login: str,
+    email: str,
+    nc_token: str,
+) -> None:
+    """Backward-compatible wrapper for the previous repository API."""
+    save_login_profile(tg_id, nc_login, email, nc_token)
+
+
+def update_nextcloud_profile(
+    nc_login: str,
+    *,
+    email: object = NEXTCLOUD_FIELD_MISSING,
+    timezone_value: object = NEXTCLOUD_FIELD_MISSING,
+) -> bool:
+    """Atomically update fields returned by an admin profile read."""
     with get_session() as session:
         stmt = select(User).where(User.nc_login == nc_login)
         user = session.execute(stmt).scalar_one_or_none()
-        if user:
-            user.nc_email = nc_email
+        if user is None:
+            return False
+
+        if email is not NEXTCLOUD_FIELD_MISSING:
+            normalized_email = _normalize_email(email)
+            if normalized_email is not None:
+                user.nc_email = normalized_email
+        _apply_nextcloud_timezone(user, timezone_value)
+        return True
+
+
+def save_email_by_username(nc_email: str, nc_login: str) -> None:
+    """Backward-compatible email-only profile update."""
+    update_nextcloud_profile(nc_login, email=nc_email)
+
+
+def get_timezone_settings(tg_id: int | None) -> TimezoneSettings:
+    """Return stored timezone inputs for a Telegram user."""
+    if tg_id is None:
+        return TimezoneSettings(None, None)
+
+    with get_session() as session:
+        user = session.get(User, tg_id)
+        if user is None:
+            return TimezoneSettings(None, None)
+        return TimezoneSettings(
+            nextcloud_tzid=user.nc_timezone,
+            override_tzid=user.timezone_override,
+        )
+
+
+def get_effective_timezone(
+    tg_id: int | None,
+    *,
+    default_tzid: str,
+) -> tzinfo:
+    """Resolve a user's effective timezone as a real tzinfo object."""
+    return resolve_effective_timezone(
+        get_timezone_settings(tg_id),
+        default_tzid=default_tzid,
+    )
+
+
+def set_timezone_override(tg_id: int, tzid: str) -> None:
+    """Validate and save a user's explicit timezone override."""
+    normalized = normalize_tzid(tzid)
+    if normalized is None:
+        raise ValueError("Unknown IANA timezone")
+
+    with get_session() as session:
+        user = session.get(User, tg_id)
+        if user is None:
+            raise UserNotFoundError(tg_id)
+        user.timezone_override = normalized
+
+
+def clear_timezone_override(tg_id: int) -> None:
+    """Clear a user's override and restore automatic resolution."""
+    with get_session() as session:
+        user = session.get(User, tg_id)
+        if user is None:
+            raise UserNotFoundError(tg_id)
+        user.timezone_override = None
+
 
 def save_timezone(tg_id: int, timezone: int) -> None:
-    """Сохраняет временную зону."""
+    """Save a legacy integer offset for rollback compatibility."""
     with get_session() as session:
-        stmt = select(User).where(User.tg_id == tg_id)
-        user = session.execute(stmt).scalar_one_or_none()
+        user = session.get(User, tg_id)
         if user:
             user.nc_time_zone = timezone
 
-def get_timezone(tg_id: int) -> Optional[int]:
-    """Возвращает временную зону."""
+
+def get_timezone(tg_id: int) -> int:
+    """Return a legacy integer offset for rollback compatibility."""
     with get_session() as session:
-        tzone = session.get(User, tg_id)
-        return tzone.nc_time_zone if tzone else 3
+        user = session.get(User, tg_id)
+        return user.nc_time_zone if user else 3
 
 
-def get_user_list() -> List[Tuple[int, str]]:
-    """Возвращает список всех пользователей в формате [(tg_id, nc_login)]."""
-    with get_session() as session:
-        stmt = select(User.tg_id, User.nc_login)
-        result = session.execute(stmt).all()
-        return [(row.tg_id, row.nc_login) for row in result]
-
-
-def get_user_map() -> Dict[str, int]:
-    """
-    Возвращает словарь { nc_login: tg_id }.
-    Используется для отправки уведомлений назначенным пользователям.
-    """
+def get_user_list() -> list[tuple[int, str]]:
+    """Return all Telegram ID and Nextcloud login pairs."""
     with get_session() as session:
         stmt = select(User.tg_id, User.nc_login)
-        result = session.execute(stmt).all()
-        return {row.nc_login: row.tg_id for row in result}
+        rows = session.execute(stmt).all()
+        return [(row.tg_id, row.nc_login) for row in rows]
 
 
-def get_users() -> List[Dict[str, str]]:
-    """
-    Возвращает список словарей { username: nc_login, password: nc_token }.
-    """
+def get_user_map() -> dict[str, int]:
+    """Return a Nextcloud-login-to-Telegram-ID mapping."""
+    with get_session() as session:
+        stmt = select(User.tg_id, User.nc_login)
+        rows = session.execute(stmt).all()
+        return {row.nc_login: row.tg_id for row in rows}
+
+
+def get_users() -> list[dict[str, str | None]]:
+    """Return stored Nextcloud credentials for background consumers."""
     with get_session() as session:
         stmt = select(User.nc_login, User.nc_token)
-        result = session.execute(stmt).all()
-        return [{"username": row.nc_login, "password": row.nc_token} for row in result]
+        rows = session.execute(stmt).all()
+        return [
+            {"username": row.nc_login, "password": row.nc_token}
+            for row in rows
+        ]
 
 
 def save_login_token(tg_id: int, token: str) -> None:
-    """Сохраняет временный токен авторизации."""
-    from source.migrations.models import NextCloudLogin
+    """Save a temporary Login Flow polling token."""
     with get_session() as session:
-        login_token = NextCloudLogin(tg_id=tg_id, token=token)
-        session.add(login_token)
+        session.add(NextCloudLogin(tg_id=tg_id, token=token))
 
 
 def delete_login_token(tg_id: int) -> None:
-    """Удаляет временный токен авторизации."""
-    from source.migrations.models import NextCloudLogin
+    """Delete a temporary Login Flow polling token."""
     with get_session() as session:
         stmt = delete(NextCloudLogin).where(NextCloudLogin.tg_id == tg_id)
         session.execute(stmt)
 
 
-def get_token(tg_id: int) -> Optional[str]:
-    """Возвращает временный токен авторизации."""
-    from source.migrations.models import NextCloudLogin
+def get_token(tg_id: int) -> str | None:
+    """Return a temporary Login Flow polling token."""
     with get_session() as session:
         login_token = session.get(NextCloudLogin, tg_id)
         return login_token.token if login_token else None
 
 
-def get_nc_token(tg_id: int) -> Optional[str]:
-    """Возвращает Nextcloud-токен пользователя."""
+def get_nc_token(tg_id: int) -> str | None:
+    """Return a user's Nextcloud app password."""
     with get_session() as session:
         user = session.get(User, tg_id)
         return user.nc_token if user else None

--- a/source/handlers.py
+++ b/source/handlers.py
@@ -3,7 +3,15 @@ from telebot.types import (InlineKeyboardMarkup, InlineKeyboardButton, WebAppInf
 from source.app_logging import logger
 from source.connections.bot_factory import bot
 from source.connections.sender import send_message_limited
-from source.db.repos.users import get_login_by_tg_id, save_login_to_db, save_login_token, delete_login_token, get_token, get_nc_token, get_email_by_tg_id, save_timezone
+from source.db.repos.users import (
+    clear_timezone_override,
+    delete_login_token,
+    get_email_by_tg_id,
+    get_login_by_tg_id,
+    get_nc_token,
+    save_login_token,
+    set_timezone_override,
+)
 from source.db.repos.tasks import save_task_to_db, get_tasks_from_users, save_task_comment, get_task_stat, upsert_task_stats
 from source.db.repos.boards import save_board_topic
 from source.connections.nextcloud_api import fetch_user_tasks, get_board_title
@@ -12,6 +20,11 @@ from source.config import COMMIT_HASH, WEB_APP_URL, OCS_BASE_URL, HEADERS
 from requests import post
 
 from source.nc_calendar import get_calendar
+from source.timezone_command import (
+    TIMEZONE_HELP,
+    InvalidTimezoneInput,
+    apply_timezone_argument,
+)
 
 
 @bot.message_handler(commands=['start'])
@@ -282,16 +295,29 @@ def timezone_handler(message):
     chat_id = message.chat.id
     user_id = message.from_user.id
 
-    command_data = message.text.split()
-    if len(command_data) < 2:
-        send_message_limited(chat_id, "Формат: \"/timezone [+/-]N\"\nПример: /timezone +4\nВремя ставить в формате UTC")
+    command_data = message.text.split(maxsplit=1)
+    if len(command_data) != 2:
+        send_message_limited(chat_id, TIMEZONE_HELP)
         return
+
     try:
-        save_timezone(user_id, int(command_data[1]))
-    except Exception as e:
-        logger.error("TIMEZONE: ой")
+        result = apply_timezone_argument(
+            command_data[1],
+            save_override=lambda tzid: set_timezone_override(
+                user_id,
+                tzid,
+            ),
+            clear_override=lambda: clear_timezone_override(user_id),
+        )
+    except InvalidTimezoneInput:
+        send_message_limited(chat_id, TIMEZONE_HELP)
+        return
+    except Exception:
+        logger.exception("TIMEZONE: database update failed")
+        send_message_limited(
+            chat_id,
+            "Не удалось сохранить timezone. Попробуйте ещё раз позже.",
+        )
+        return
 
-
-    send_message_limited(chat_id, f"Твоя зона изменена, поздравляю с переездом!")
-
-
+    send_message_limited(chat_id, result)

--- a/source/migrations/init_db.py
+++ b/source/migrations/init_db.py
@@ -1,5 +1,8 @@
+from sqlalchemy.engine import Connection, Engine
+
 from source.db.db import engine
 from source.migrations.models import Base
 
-def init_db():
-    Base.metadata.create_all(bind=engine)
+
+def init_db(bind: Engine | Connection = engine) -> None:
+    Base.metadata.create_all(bind=bind)

--- a/source/migrations/migration.py
+++ b/source/migrations/migration.py
@@ -1,71 +1,68 @@
 from pathlib import Path
-from alembic.config import Config
-from alembic import command
-from alembic.util.exc import CommandError
-from alembic.autogenerate import compare_metadata
-from alembic.runtime.migration import MigrationContext
-from sqlalchemy import create_engine, inspect, text
-from source.db.db import Base, DATABASE_URL
-from source.app_logging import logger
-import datetime
 
-def get_alembic_config():
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import Connection
+
+from alembic import command
+from source.app_logging import logger
+from source.db.db import DATABASE_URL
+
+
+def get_alembic_config(database_url: str = DATABASE_URL) -> Config:
     base_dir = Path(__file__).resolve().parent.parent.parent
     ini_path = base_dir / "alembic.ini"
 
     cfg = Config(str(ini_path))
 
-    cfg.attributes['configure_logger'] = False
-    cfg.set_main_option("sqlalchemy.url", DATABASE_URL)
+    cfg.attributes["configure_logger"] = False
+    cfg.set_main_option("sqlalchemy.url", database_url)
     cfg.set_main_option("script_location", str(base_dir / "alembic"))
     return cfg
 
 
-def auto_migrate():
-    cfg = get_alembic_config()
-    db_url = cfg.get_main_option("sqlalchemy.url")
-    engine = create_engine(db_url)
+def _discard_orphaned_revisions(
+    connection: Connection,
+    cfg: Config,
+) -> None:
+    if not inspect(connection).has_table("alembic_version"):
+        return
 
-    with engine.connect() as connection:
-        logger.info("Синхронизация с существующими миграциями...")
-        try:
+    current_revisions = set(
+        connection.execute(
+            text("SELECT version_num FROM alembic_version")
+        ).scalars()
+    )
+    known_revisions = {
+        item.revision
+        for item in ScriptDirectory.from_config(cfg).walk_revisions()
+    }
+    orphaned_revisions = current_revisions - known_revisions
+    if not orphaned_revisions:
+        return
+
+    logger.warning(
+        "Обнаружены legacy runtime-ревизии Alembic; "
+        "они будут заменены через committed upgrade."
+    )
+    for revision in orphaned_revisions:
+        connection.execute(
+            text("DELETE FROM alembic_version WHERE version_num = :revision"),
+            {"revision": revision},
+        )
+
+
+def auto_migrate(database_url: str = DATABASE_URL) -> None:
+    """Apply committed migrations without changing migration history."""
+    logger.info("Применение миграций базы данных...")
+    cfg = get_alembic_config(database_url)
+    engine = create_engine(database_url)
+    try:
+        with engine.begin() as connection:
+            _discard_orphaned_revisions(connection, cfg)
+            cfg.attributes["connection"] = connection
             command.upgrade(cfg, "head")
-        except CommandError as e:
-            if "Can't locate revision identified by" not in str(e):
-                raise
-
-            logger.info(
-                "Обнаружена неизвестная ревизия Alembic в базе. "
-                "Очищаем alembic_version и пересинхронизируемся с текущим head."
-            )
-            with engine.connect() as conn:
-                if inspect(conn).has_table("alembic_version"):
-                    conn.execute(text("DELETE FROM alembic_version"))
-                    conn.commit()
-
-            command.stamp(cfg, "head")
-
-        mc = MigrationContext.configure(connection)
-        diff = compare_metadata(mc, Base.metadata)
-
-        if not diff:
-            logger.info("Изменений в моделях не найдено. База актуальна.")
-            return
-
-        logger.info(f"Обнаружены изменения: {diff}")
-
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M")
-
-        try:
-            command.revision(
-                cfg,
-                message=f"auto_migration_{timestamp}",
-                autogenerate=True
-            )
-            logger.info(f"Создан новый файл миграции.")
-
-            command.upgrade(cfg, "head")
-            logger.info("База успешно обновлена!")
-
-        except Exception as e:
-            logger.error(f"Ошибка при создании миграции: {e}")
+    finally:
+        engine.dispose()
+    logger.info("Миграции базы данных применены.")

--- a/source/migrations/models.py
+++ b/source/migrations/models.py
@@ -14,6 +14,8 @@ class User(Base):
     nc_login = Column(String(100), nullable=False)
     nc_email = Column(String(255), nullable=True)
     nc_time_zone = Column(Integer, nullable=False, default=3)
+    nc_timezone = Column(String(64), nullable=True)
+    timezone_override = Column(String(64), nullable=True)
     nc_token = Column(String(100), nullable=True)
 
 class Task(Base):

--- a/source/nc_calendar.py
+++ b/source/nc_calendar.py
@@ -1,6 +1,12 @@
 from source.config import WEB_CALDAV_URL, USERNAME, PASSWORD, COOLDOWN_TUESDAY, COOLDOWN_SUNDAY, COOLDOWN_DEFAULT, \
     POLL_INTERVAL, WEB_APP_URL, UPDATE_INTERVAL, TIMEZONE, CALDAV_USERNAME, CALDAV_PASSWORD, CALDAV_COOLDOWNS
 from source.connections.sender import send_message_limited
+from source.calendar_time import (
+    UnknownSourceTimezoneError,
+    local_day_window,
+    local_week_window,
+    localize_ical_value,
+)
 from source.datetime_formatting import format_calendar_time
 from source.db.repos.users import (
     NEXTCLOUD_FIELD_MISSING,
@@ -19,12 +25,14 @@ from telebot.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 from caldav import DAVClient, error
 from icalendar import Calendar, vText
-from datetime import date, datetime, time, timedelta, timezone, tzinfo
+from datetime import date, datetime, time, timedelta, timezone
 
 from time import sleep
 from zoneinfo import ZoneInfo
 
 import requests
+
+_DATETIME_TYPE = datetime
 
 try:
     TEAM_TZ = ZoneInfo(TIMEZONE)
@@ -49,9 +57,58 @@ WEEKDAY_RU = {
     None: " ОПРЕДЕЛЕННЫЙ ДЕНЬ"
 }
 
+
+def _source_tzid(property_value) -> str | None:
+    params = getattr(property_value, "params", {})
+    source_tzid = params.get("TZID")
+    if source_tzid is None:
+        return None
+
+    return str(source_tzid)
+
+
+def _localized_component_value(component, name: str, target_timezone):
+    property_value = component.get(name)
+    if property_value is None:
+        return "Неизвестно"
+
+    return localize_ical_value(
+        property_value.dt,
+        target_timezone=target_timezone,
+        source_tzid=_source_tzid(property_value),
+    )
+
+
+def _format_localized_value(value) -> str:
+    if isinstance(value, _DATETIME_TYPE):
+        return format_calendar_time(value)
+
+    return str(value)
+
+
+def _localized_sort_key(item):
+    value = item[0]
+    if isinstance(value, _DATETIME_TYPE):
+        return (
+            value.date().toordinal(),
+            value.hour,
+            value.minute,
+            value.second,
+            value.microsecond,
+        )
+    if isinstance(value, date):
+        return (value.toordinal(), 0, 0, 0, 0)
+
+    return (float("inf"), 0, 0, 0, 0)
+
+
 def msg_design_from_button(uid: str, teg_id: int, type_msg: int):
     start = datetime.now(TEAM_TZ)
     end = start + timedelta(days=6)
+    tz_user = get_effective_timezone(
+        teg_id,
+        default_tzid=TIMEZONE,
+    )
     client = DAVClient(WEB_CALDAV_URL, username=CALDAV_USERNAME, password=CALDAV_PASSWORD)
     principal = client.principal()
     res = ''
@@ -67,23 +124,18 @@ def msg_design_from_button(uid: str, teg_id: int, type_msg: int):
                         description = str(component.get("description", "Нет описания"))
                         location = str(component.get("location", "Не указана"))
 
-                        start_dt = component.get("dtstart").dt if component.get("dtstart") else "Неизвестно"
-                        end_dt = component.get("dtend").dt if component.get("dtend") else "Неизвестно"
-
-                        tz_user = get_effective_timezone(
-                            teg_id,
-                            default_tzid=TIMEZONE,
+                        start_dt = _localized_component_value(
+                            component,
+                            "dtstart",
+                            tz_user,
                         )
-
-                        if isinstance(start_dt, datetime):
-                            start_dt_str = format_to_timezone(start_dt, tz=tz_user) if start_dt else "Неизвестно"
-                        else:
-                            start_dt_str = str(start_dt)
-
-                        if isinstance(end_dt, datetime):
-                            end_dt_str = format_to_timezone(end_dt, tz=tz_user) if end_dt else "Неизвестно"
-                        else:
-                            end_dt_str = str(end_dt)
+                        end_dt = _localized_component_value(
+                            component,
+                            "dtend",
+                            tz_user,
+                        )
+                        start_dt_str = _format_localized_value(start_dt)
+                        end_dt_str = _format_localized_value(end_dt)
 
                         if type_msg == 2:
                             res += (f'📅 *СЕГОДНЯ СОБЫТИЕ В{WEEKDAY_RU.get(start_dt.weekday(), "ОПРЕДЕЛЕННЫЙ ДЕНЬ")}*\n'
@@ -204,14 +256,6 @@ def cleanup_uid(target_uid: str):
         except Exception as e:
             print(e)
 
-def format_to_timezone(dt: datetime, tz: tzinfo) -> str:
-    """Преобразует datetime в timezone и возвращает время ЧЧ:ММ."""
-    if not isinstance(dt, datetime):
-        return str(dt)
-
-    return format_calendar_time(dt, tz)
-
-
 def sync_nextcloud_users_once(
     *,
     request_get=requests.get,
@@ -311,13 +355,17 @@ def get_all_participants(component):
 
 
 def get_calendar(teg_id, cooldown=6, all_events=False):
-    start = datetime.now(TEAM_TZ)
+    tz_user = get_effective_timezone(
+        teg_id,
+        default_tzid=TIMEZONE,
+    )
+    now_utc = datetime.now(timezone.utc)
     if cooldown == 1:
-        end = start.replace(hour=23, minute=59, second=59, microsecond=999999)
-    elif cooldown == 7:
-        start = start.replace(hour=0, minute=0, second=0, microsecond=0)
-        end = start + timedelta(days=cooldown - 1)
+        start, end = local_day_window(now_utc, tz_user)
+    elif cooldown in (6, 7):
+        start, end = local_week_window(now_utc, tz_user)
     else:
+        start = now_utc
         end = start + timedelta(days=cooldown)
 
     result = []
@@ -339,28 +387,20 @@ def get_calendar(teg_id, cooldown=6, all_events=False):
                         description = str(component.get("description", "Нет описания"))
                         location = str(component.get("location", "Не указана"))
 
-                        start_dt = component.get("dtstart").dt if component.get("dtstart") else "Неизвестно"
-                        end_dt = component.get("dtend").dt if component.get("dtend") else "Неизвестно"
-
-                        tz_user = get_effective_timezone(
-                            teg_id,
-                            default_tzid=TIMEZONE,
+                        start_dt = _localized_component_value(
+                            component,
+                            "dtstart",
+                            tz_user,
+                        )
+                        end_dt = _localized_component_value(
+                            component,
+                            "dtend",
+                            tz_user,
                         )
 
-                        if component.get("dtstart").dt < start and component.get("dtstart").dt > end:
-                            continue
-
                         short_url = event_uid
-
-                        if isinstance(start_dt, datetime):
-                            start_dt_str = format_to_timezone(start_dt, tz=tz_user) if start_dt else "Неизвестно"
-                        else:
-                            start_dt_str = str(start_dt)
-
-                        if isinstance(end_dt, datetime):
-                            end_dt_str = format_to_timezone(end_dt, tz=tz_user) if end_dt else "Неизвестно"
-                        else:
-                            end_dt_str = str(end_dt)
+                        start_dt_str = _format_localized_value(start_dt)
+                        end_dt_str = _format_localized_value(end_dt)
 
                         res += (f'📅 *СОБЫТИЕ В{WEEKDAY_RU.get(start_dt.weekday(), "ОПРЕДЕЛЕННЫЙ ДЕНЬ")}*\n'
                                 f'{summary}\n'
@@ -447,16 +487,7 @@ def get_calendar(teg_id, cooldown=6, all_events=False):
             logger.error(f"CALDAV: {e}")
             return None
 
-    def get_sort_key(item):
-        dt = item[0]
-        if isinstance(dt, datetime):
-            return dt.timestamp()
-        elif isinstance(dt, date):
-            return datetime.combine(dt, datetime.min.time()).timestamp()
-
-        return float('inf')
-
-    result.sort(key=get_sort_key)
+    result.sort(key=_localized_sort_key)
 
     final_result = [item[1] for item in result]
 
@@ -548,9 +579,8 @@ def poll_events():
     while True:
         logger.info(f"CALDAV: Получаю события...")
 
-        start = datetime.now(TEAM_TZ)
-
-        end = start + timedelta(days=1)
+        now_utc = datetime.now(timezone.utc)
+        end_utc = now_utc + timedelta(hours=24)
         saved_event_keys = get_sent_event_keys()
         observed_event_keys: set[SentEventKey] = set()
         scan_complete = True
@@ -564,7 +594,7 @@ def poll_events():
 
         for calendar in calendars:
             try:
-                events = calendar.date_search(start=start, end=end)
+                events = calendar.date_search(start=now_utc, end=end_utc)
             except Exception as e:
                 logger.error(f"CALDAV: Ошибка поиска событий в календаре: {e}")
                 scan_complete = False
@@ -577,6 +607,13 @@ def poll_events():
 
                     for component in cal.walk():
                         if component.name == "VEVENT":
+                            start_property = component.get("dtstart")
+                            if start_property is None:
+                                continue
+                            start_dt = start_property.dt
+                            if not isinstance(start_dt, datetime):
+                                continue
+
                             event_uid = str(component.get("uid"))
                             if component.get("uid") is None:
                                 event_uid = str(component.get("dtstart"))
@@ -587,22 +624,15 @@ def poll_events():
                             summary = str(component.get("summary", "Без названия"))
                             description = str(component.get("description", "Нет описания"))
                             location = str(component.get("location", "Не указана"))
-                            start_dt = component.get("dtstart").dt if component.get("dtstart") else "Неизвестно"
-                            end_dt = component.get("dtend").dt if component.get("dtend") else "Неизвестно"
+                            end_property = component.get("dtend")
                             cooldowns = []
-                            if not isinstance(start_dt, str):
-                                find_need_event = False
-                                for key, value in CALDAV_COOLDOWNS.items():
-                                    if summary.startswith(key):
-                                        for i in value:
-                                            if (start_dt - start) <= timedelta(minutes=i):
-                                                find_need_event = True
-                                                cooldowns = value
-                                                break
-                                        break
+                            for key, value in CALDAV_COOLDOWNS.items():
+                                if summary.startswith(key):
+                                    cooldowns = value
+                                    break
 
-                                if not find_need_event:
-                                    continue
+                            if not cooldowns:
+                                continue
 
 
 
@@ -610,7 +640,7 @@ def poll_events():
 
                             attendees = get_all_participants(component)
                             name_for_send = ""
-                            pending_event_keys: dict[int, SentEventKey] = {}
+                            pending_event_contexts = {}
                             if attendees:
                                 for user in attendees:
                                     email = user.get('email')
@@ -619,6 +649,7 @@ def poll_events():
                                     tg_id_found = get_tg_id_by_email(email)
                                     if tg_id_found is None:
                                         continue
+
                                     user_event_keys = [
                                         SentEventKey(
                                             telegram_id=tg_id_found,
@@ -627,6 +658,57 @@ def poll_events():
                                         )
                                         for cooldown in cooldowns
                                     ]
+                                    tz_user = get_effective_timezone(
+                                        tg_id_found,
+                                        default_tzid=TIMEZONE,
+                                    )
+                                    try:
+                                        localized_start = (
+                                            localize_ical_value(
+                                                start_dt,
+                                                target_timezone=tz_user,
+                                                source_tzid=_source_tzid(
+                                                    start_property
+                                                ),
+                                            )
+                                        )
+
+                                        localized_end = None
+                                        if end_property is not None:
+                                            localized_end = (
+                                                localize_ical_value(
+                                                    end_property.dt,
+                                                    target_timezone=tz_user,
+                                                    source_tzid=_source_tzid(
+                                                        end_property
+                                                    ),
+                                                )
+                                            )
+                                    except UnknownSourceTimezoneError as e:
+                                        scan_complete = False
+                                        logger.error(
+                                            "CALDAV: Неизвестный TZID "
+                                            f"{e.tzid} у события "
+                                            f"{event_uid} для {email}"
+                                        )
+                                        continue
+
+                                    start_instant = (
+                                        localized_start.astimezone(
+                                            timezone.utc
+                                        )
+                                    )
+                                    time_until_start = (
+                                        start_instant - now_utc
+                                    )
+                                    if not (
+                                        timedelta() <= time_until_start
+                                        <= timedelta(
+                                            minutes=max(cooldowns)
+                                        )
+                                    ):
+                                        continue
+
                                     observed_event_keys.update(
                                         user_event_keys
                                     )
@@ -635,13 +717,23 @@ def poll_events():
                                             key
                                             for key in user_event_keys
                                             if key not in saved_event_keys
+                                            and time_until_start
+                                            <= timedelta(
+                                                minutes=(
+                                                    key.cooldown_minutes
+                                                )
+                                            )
                                         ),
                                         None,
                                     )
                                     if pending_event_key is not None:
-                                        pending_event_keys[
+                                        pending_event_contexts[
                                             tg_id_found
-                                        ] = pending_event_key
+                                        ] = (
+                                            pending_event_key,
+                                            localized_start,
+                                            localized_end,
+                                        )
 
                                 for user in attendees:
                                     email = user.get('email')
@@ -650,27 +742,39 @@ def poll_events():
                                     teg_id = get_tg_id_by_email(email)
                                     if teg_id is None:
                                         continue
-                                    event_key = pending_event_keys.get(teg_id)
-                                    if event_key is None:
-                                        continue
-
-                                    tz_user = get_effective_timezone(
-                                        teg_id,
-                                        default_tzid=TIMEZONE,
+                                    event_context = (
+                                        pending_event_contexts.get(teg_id)
                                     )
+                                    if event_context is None:
+                                        continue
+                                    (
+                                        event_key,
+                                        localized_start,
+                                        localized_end,
+                                    ) = event_context
 
-                                    if isinstance(start_dt, datetime):
-                                        start_dt_str = format_to_timezone(start_dt, tz=tz_user) if start_dt else "Неизвестно"
+                                    start_dt_str = format_calendar_time(
+                                        localized_start
+                                    )
+                                    if isinstance(
+                                        localized_end,
+                                        datetime,
+                                    ):
+                                        end_dt_str = format_calendar_time(
+                                            localized_end
+                                        )
+                                    elif localized_end is None:
+                                        end_dt_str = "Неизвестно"
                                     else:
-                                        start_dt_str = str(start_dt)
-
-                                    if isinstance(end_dt, datetime):
-                                        end_dt_str = format_to_timezone(end_dt, tz=tz_user) if end_dt else "Неизвестно"
-                                    else:
-                                        end_dt_str = str(end_dt)
+                                        end_dt_str = str(localized_end)
 
 
-                                    res = (f'📅 *СЕГОДНЯ СОБЫТИЕ В{WEEKDAY_RU.get(start_dt.weekday(), "ОПРЕДЕЛЕННЫЙ ДЕНЬ")}*\n'
+                                    localized_weekday = WEEKDAY_RU.get(
+                                        localized_start.weekday(),
+                                        "ОПРЕДЕЛЕННЫЙ ДЕНЬ",
+                                    )
+                                    res = ('📅 *СЕГОДНЯ СОБЫТИЕ В'
+                                           f'{localized_weekday}*\n'
                                            f'{summary}\n'
                                            f'{description}\n\n'
                                            f'Локация: {location}\n\n'

--- a/source/nc_calendar.py
+++ b/source/nc_calendar.py
@@ -3,7 +3,12 @@ from source.config import WEB_CALDAV_URL, USERNAME, PASSWORD, COOLDOWN_TUESDAY, 
 from source.connections.sender import send_message_limited
 from source.db.repos.users import get_tg_id_by_email, save_email_by_username, get_timezone
 from source.app_logging import logger
-from source.db.repos.caldav_calendar import get_events_from_db, save_event_sends, delete_event_sends, get_id_by_name
+from source.caldav_notification_state import SentEventKey, find_stale_keys
+from source.db.repos.caldav_calendar import (
+    delete_sent_event,
+    get_sent_event_keys,
+    save_event_send,
+)
 from telebot.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 from caldav import DAVClient, error
@@ -608,9 +613,9 @@ def poll_events():
         start = datetime.now(TEAM_TZ)
 
         end = start + timedelta(days=1)
-        all_sended_events_uids = get_events_from_db()
-        current_found_uids = set()
-        caldav_error_occurred = False
+        saved_event_keys = get_sent_event_keys()
+        observed_event_keys: set[SentEventKey] = set()
+        scan_complete = True
 
         try:
             calendars = principal.calendars()
@@ -624,7 +629,7 @@ def poll_events():
                 events = calendar.date_search(start=start, end=end)
             except Exception as e:
                 logger.error(f"CALDAV: Ошибка поиска событий в календаре: {e}")
-                caldav_error_occurred = True
+                scan_complete = False
                 continue
 
             for event in events:
@@ -667,33 +672,45 @@ def poll_events():
 
                             attendees = get_all_participants(component)
                             name_for_send = ""
-                            teg_id_and_uid = event_uid
-                            list_not_send_tg_id = []
-                            now_cooldown_send = cooldowns[0]
+                            pending_event_keys: dict[int, SentEventKey] = {}
                             if attendees:
                                 for user in attendees:
                                     email = user.get('email')
                                     if email is None:
                                         continue
                                     tg_id_found = get_tg_id_by_email(email)
-                                    for i in cooldowns:
-                                        teg_id_and_uid = f"{tg_id_found}_{i}_{event_uid}"
-                                        current_found_uids.add(teg_id_and_uid)
-                                        if teg_id_and_uid not in all_sended_events_uids:
-                                            now_cooldown_send = i
-                                            break
-
-                                    if teg_id_and_uid in all_sended_events_uids:
-                                        list_not_send_tg_id.append(tg_id_found)
+                                    if tg_id_found is None:
                                         continue
-
-                                    all_sended_events_uids.add(teg_id_and_uid)
+                                    user_event_keys = [
+                                        SentEventKey(
+                                            telegram_id=tg_id_found,
+                                            cooldown_minutes=cooldown,
+                                            event_uid=event_uid,
+                                        )
+                                        for cooldown in cooldowns
+                                    ]
+                                    observed_event_keys.update(
+                                        user_event_keys
+                                    )
+                                    pending_event_key = next(
+                                        (
+                                            key
+                                            for key in user_event_keys
+                                            if key not in saved_event_keys
+                                        ),
+                                        None,
+                                    )
+                                    if pending_event_key is not None:
+                                        pending_event_keys[
+                                            tg_id_found
+                                        ] = pending_event_key
 
                                 for user in attendees:
                                     email = user.get('email')
                                     if email is None:
                                         continue
                                     teg_id = get_tg_id_by_email(email)
+                                    event_key = pending_event_keys.get(teg_id)
 
                                     tz_user = get_timezone(teg_id)
 
@@ -752,7 +769,7 @@ def poll_events():
                                     if res[-1] == '\n': res = res[:-1]
                                     res += '///'
 
-                                    if teg_id and teg_id not in list_not_send_tg_id:
+                                    if teg_id and event_key is not None:
                                         markup = InlineKeyboardMarkup()
                                         if short_url is not None:
                                             accept = "success" if user['status'] == "ACCEPTED" else None
@@ -772,19 +789,30 @@ def poll_events():
                                             else:
                                                 markup.row(btn_update)
                                         send_message_limited(teg_id, res, reply_markup=markup)
-                                        save_event_sends(name_for_send, teg_id, now_cooldown_send, event_uid, event_url)
+                                        save_event_send(
+                                            name_for_send,
+                                            event_key,
+                                            event_url,
+                                        )
+                                        saved_event_keys.add(event_key)
 
                 except Exception as e:
+                    scan_complete = False
                     logger.exception(f"CALDAV: ой {e}")
 
-        if not caldav_error_occurred:
-            deleted_events_uids = all_sended_events_uids - current_found_uids
-            for del_uid in deleted_events_uids:
-                try:
-                    uid_for_delete = del_uid.split('_')[-1]
-                    set_all_attendees_needs_action(uid_for_delete)
-                    delete_event_sends(uid_for_delete)
-                except Exception as e:
-                    logger.error(f"CALDAV: Ошибка удаления события из БД: {e}")
+        stale_keys = find_stale_keys(
+            saved_event_keys,
+            observed_event_keys,
+            scan_complete=scan_complete,
+        )
+        for stale_key in stale_keys:
+            try:
+                set_all_attendees_needs_action(stale_key.event_uid)
+                delete_sent_event(stale_key)
+            except Exception as e:
+                logger.error(
+                    "CALDAV: Ошибка удаления "
+                    f"события из БД: {e}"
+                )
 
         sleep(POLL_INTERVAL)

--- a/source/nc_calendar.py
+++ b/source/nc_calendar.py
@@ -637,7 +637,11 @@ def poll_events():
                                     if email is None:
                                         continue
                                     teg_id = get_tg_id_by_email(email)
+                                    if teg_id is None:
+                                        continue
                                     event_key = pending_event_keys.get(teg_id)
+                                    if event_key is None:
+                                        continue
 
                                     tz_user = get_timezone(teg_id)
 

--- a/source/nc_calendar.py
+++ b/source/nc_calendar.py
@@ -1,7 +1,13 @@
 from source.config import WEB_CALDAV_URL, USERNAME, PASSWORD, COOLDOWN_TUESDAY, COOLDOWN_SUNDAY, COOLDOWN_DEFAULT, \
-    POLL_INTERVAL, WEB_APP_URL, UPDATE_INTERVAL, TIMEZONE, CALDAV_USERNAME, CALDAV_PASSWORD, CALDAV_COOLDOWNS, TIMEZONES
+    POLL_INTERVAL, WEB_APP_URL, UPDATE_INTERVAL, TIMEZONE, CALDAV_USERNAME, CALDAV_PASSWORD, CALDAV_COOLDOWNS
 from source.connections.sender import send_message_limited
-from source.db.repos.users import get_tg_id_by_email, save_email_by_username, get_timezone
+from source.datetime_formatting import format_calendar_time
+from source.db.repos.users import (
+    NEXTCLOUD_FIELD_MISSING,
+    get_effective_timezone,
+    get_tg_id_by_email,
+    update_nextcloud_profile,
+)
 from source.app_logging import logger
 from source.caldav_notification_state import SentEventKey, find_stale_keys
 from source.db.repos.caldav_calendar import (
@@ -13,7 +19,7 @@ from telebot.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 from caldav import DAVClient, error
 from icalendar import Calendar, vText
-from datetime import datetime, timedelta, timezone, time, date
+from datetime import date, datetime, time, timedelta, timezone, tzinfo
 
 from time import sleep
 from zoneinfo import ZoneInfo
@@ -64,7 +70,10 @@ def msg_design_from_button(uid: str, teg_id: int, type_msg: int):
                         start_dt = component.get("dtstart").dt if component.get("dtstart") else "Неизвестно"
                         end_dt = component.get("dtend").dt if component.get("dtend") else "Неизвестно"
 
-                        tz_user = get_timezone(teg_id)
+                        tz_user = get_effective_timezone(
+                            teg_id,
+                            default_tzid=TIMEZONE,
+                        )
 
                         if isinstance(start_dt, datetime):
                             start_dt_str = format_to_timezone(start_dt, tz=tz_user) if start_dt else "Неизвестно"
@@ -195,20 +204,54 @@ def cleanup_uid(target_uid: str):
         except Exception as e:
             print(e)
 
-def format_to_timezone(dt: datetime, tz: int) -> str:
-    """Преобразует datetime в указанный UTC-сдвиг и возвращает время ЧЧ:ММ."""
+def format_to_timezone(dt: datetime, tz: tzinfo) -> str:
+    """Преобразует datetime в timezone и возвращает время ЧЧ:ММ."""
     if not isinstance(dt, datetime):
         return str(dt)
 
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
+    return format_calendar_time(dt, tz)
 
-    tz = TIMEZONES.get(tz)
-    if tz is None:
-        logger.error(f"CALDAV: Неизвестный UTC-сдвиг: {tz}")
-        tz = 3
 
-    return dt.astimezone(tz).strftime("%H:%M")
+def sync_nextcloud_users_once(
+    *,
+    request_get=requests.get,
+    update_profile=update_nextcloud_profile,
+) -> int:
+    """Read and persist Nextcloud profiles once without remote writes."""
+    headers = {
+        "OCS-APIRequest": "true",
+        "Accept": "application/json",
+    }
+    auth = (USERNAME, PASSWORD)
+    users_endpoint = f"{WEB_APP_URL}/ocs/v1.php/cloud/users?limit=1000"
+    response = request_get(users_endpoint, headers=headers, auth=auth)
+    response.raise_for_status()
+    user_ids = response.json().get("ocs", {}).get("data", {}).get(
+        "users",
+        [],
+    )
+
+    updated_count = 0
+    for uid in user_ids:
+        detail_endpoint = f"{WEB_APP_URL}/ocs/v1.php/cloud/users/{uid}"
+        detail_response = request_get(
+            detail_endpoint,
+            headers=headers,
+            auth=auth,
+        )
+        detail_response.raise_for_status()
+        user_data = detail_response.json().get("ocs", {}).get("data", {})
+        updated = update_profile(
+            uid,
+            email=user_data.get("email", NEXTCLOUD_FIELD_MISSING),
+            timezone_value=user_data.get(
+                "timezone",
+                NEXTCLOUD_FIELD_MISSING,
+            ),
+        )
+        updated_count += int(updated)
+
+    return updated_count
 
 def sync_nextcloud_users():
     """
@@ -216,53 +259,18 @@ def sync_nextcloud_users():
     ВНИМАНИЕ: Пользователь (USERNAME), указанный в конфиге,
     должен иметь права Администратора в Nextcloud.
     """
-    headers = {
-        "OCS-APIRequest": "true",
-        "Accept": "application/json"
-    }
-
-    auth = (USERNAME, PASSWORD)
     while True:
         logger.info(f"NEXTCLOUD: Начинаю синхронизацию пользователей (частота {UPDATE_INTERVAL} дней)...")
         try:
-
-            users_endpoint = f"{WEB_APP_URL}/ocs/v1.php/cloud/users?limit=1000"
-            response = requests.get(users_endpoint, headers=headers, auth=auth)
-
-            if response.status_code != 200:
-                logger.error(
-                    f"CLOUD: Ошибка доступа к API. Код: {response.status_code}. Проверьте, является ли {USERNAME} админом.")
-                return
-
-            data = response.json()
-            try:
-                user_ids = data.get('ocs', {}).get('data', {}).get('users', {})
-            except AttributeError:
-                return
-
-            updated_count = 0
-            for uid in user_ids:
-                detail_endpoint = f"{WEB_APP_URL}/ocs/v1.php/cloud/users/{uid}"
-                detail_res = requests.get(detail_endpoint, headers=headers, auth=auth)
-                detail_res.raise_for_status()
-                if detail_res.status_code == 200:
-                    user_data = detail_res.json().get('ocs', {}).get('data', {})
-                    try:
-                        email = user_data.get('email', '').strip().lower()
-                    except AttributeError:
-                        continue
-                    if email:
-                        save_email_by_username(
-                            nc_login=uid,
-                            nc_email=email,
-                        )
-                        updated_count += 1
-
-            logger.info(f"CLOUD: Успешно синхронизировано {updated_count} пользователей с почтой.")
-            sleep(86400 * UPDATE_INTERVAL)
+            updated_count = sync_nextcloud_users_once()
+            logger.info(
+                "CLOUD: Синхронизировано профилей: %s",
+                updated_count,
+            )
 
         except Exception as e:
             logger.exception(f"CLOUD: Критическая ошибка при синхронизации пользователей: {e}")
+        sleep(86400 * UPDATE_INTERVAL)
 
 def get_all_participants(component):
     """
@@ -334,7 +342,10 @@ def get_calendar(teg_id, cooldown=6, all_events=False):
                         start_dt = component.get("dtstart").dt if component.get("dtstart") else "Неизвестно"
                         end_dt = component.get("dtend").dt if component.get("dtend") else "Неизвестно"
 
-                        tz_user = get_timezone(teg_id)
+                        tz_user = get_effective_timezone(
+                            teg_id,
+                            default_tzid=TIMEZONE,
+                        )
 
                         if component.get("dtstart").dt < start and component.get("dtstart").dt > end:
                             continue
@@ -643,7 +654,10 @@ def poll_events():
                                     if event_key is None:
                                         continue
 
-                                    tz_user = get_timezone(teg_id)
+                                    tz_user = get_effective_timezone(
+                                        teg_id,
+                                        default_tzid=TIMEZONE,
+                                    )
 
                                     if isinstance(start_dt, datetime):
                                         start_dt_str = format_to_timezone(start_dt, tz=tz_user) if start_dt else "Неизвестно"

--- a/source/nc_calendar.py
+++ b/source/nc_calendar.py
@@ -530,79 +530,6 @@ def update_event_partstat(event_uid: str, user_email: str, new_status: str) -> b
         return False
 
 
-def set_all_attendees_needs_action(event_uid: str) -> bool:
-    """
-    Устанавливает статус NEEDS-ACTION (Ожидает решения)
-    для всех участников (ATTENDEE) указанного события.
-
-    event_uid: UID события
-    """
-    try:
-        start = datetime.now(TEAM_TZ)
-        end = start + timedelta(days=7)
-
-        client = DAVClient(WEB_CALDAV_URL, username=CALDAV_USERNAME, password=CALDAV_PASSWORD)
-        principal = client.principal()
-
-        target_event = None
-
-        calendars = principal.calendars()
-        for calendar in calendars:
-            try:
-                events = calendar.date_search(start=start, end=end, expand=True)
-                for event in events:
-                    ical = event.icalendar_instance
-                    for component in ical.walk('VEVENT'):
-                        if str(component.get('UID')) == event_uid:
-                            target_event = event
-                            logger.info(f"Событие найдено в календаре '{calendar.name}', {component.get('summary')} {component.get('dtstart').dt}")
-                            break
-                    if target_event: break
-            except Exception as e:
-                logger.debug(f"Пропуск календаря {calendar.name}: {e}")
-                continue
-            if target_event: break
-
-        if not target_event:
-            logger.error(f"Не удалось найти событие {event_uid} для сброса статусов")
-            return False
-
-        ical = target_event.icalendar_instance
-        updated = False
-
-        for component in ical.walk('VEVENT'):
-            if str(component.get('UID')) != event_uid:
-                continue
-
-            attendees = component.get('ATTENDEE')
-            if not attendees:
-                continue
-
-            if not isinstance(attendees, list):
-                attendees = [attendees]
-
-            for attendee in attendees:
-                attendee.params['PARTSTAT'] = [vText('NEEDS-ACTION')]
-                attendee.params['RSVP'] = [vText('TRUE')]
-                updated = True
-
-        if updated:
-            target_event.icalendar_instance = ical
-            try:
-                target_event.save()
-                logger.info(f"Статус 'NEEDS-ACTION' успешно установлен для всех участников события {event_uid}")
-                return True
-            except Exception as e:
-                logger.error(f"Ошибка сохранения события {event_uid}: {e}")
-                return False
-        else:
-            logger.warning(f"У события {event_uid} нет списка участников (ATTENDEE). Изменять нечего.")
-            return False
-
-    except Exception as e:
-        logger.exception(f"Критический сбой функции set_all_attendees_needs_action: {e}")
-        return False
-
 def poll_events():
     client = DAVClient(WEB_CALDAV_URL, username=CALDAV_USERNAME, password=CALDAV_PASSWORD)
     principal = client.principal()
@@ -807,7 +734,6 @@ def poll_events():
         )
         for stale_key in stale_keys:
             try:
-                set_all_attendees_needs_action(stale_key.event_uid)
                 delete_sent_event(stale_key)
             except Exception as e:
                 logger.error(

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv>=1.0.0
 caldav<2.0.0
 icalendar>=5.0.0,<6.0.0
 urllib3==1.26.20
+tzdata==2026.3

--- a/source/scheduler.py
+++ b/source/scheduler.py
@@ -2,14 +2,20 @@ import time
 import re
 import difflib
 import traceback
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone, tzinfo
 from collections import Counter
 from telebot.types import InlineKeyboardMarkup, InlineKeyboardButton
 
-from source.config import POLL_INTERVAL, EXCLUDED_CARD_IDS, ARCHIVE_AFTER_DAYS, TIMEZONES
+from source.config import (
+    ARCHIVE_AFTER_DAYS,
+    EXCLUDED_CARD_IDS,
+    POLL_INTERVAL,
+    TIMEZONE,
+)
+from source.datetime_formatting import format_task_due_date
 from source.connections.sender import send_message_limited
 from source.connections.nextcloud_api import fetch_all_tasks, in_done_stack, archive_card, get_url_attachment
-from source.db.repos.users import get_user_map, get_timezone
+from source.db.repos.users import get_effective_timezone, get_user_map
 from source.db.repos.tasks import (
     get_saved_tasks, save_task_to_db, update_task_in_db,
     get_task_assignees, save_task_assignee, delete_task_assignee,
@@ -23,20 +29,32 @@ from source.app_logging import logger, is_debug
 from source.logging_service import send_log
 from source.links import card_url
 
-def format_to_timezone(dt: datetime, tz: int) -> str:
-    """Преобразует datetime в указанный UTC-сдвиг и возвращает время ЧЧ:ММ."""
+def format_to_timezone(dt: datetime, tz: tzinfo) -> str:
+    """Преобразует UTC datetime в timezone пользователя."""
     if not isinstance(dt, datetime):
         return str(dt)
 
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
+    return format_task_due_date(dt, tz)
 
-    tz = TIMEZONES.get(tz)
-    if tz is None:
-        logger.error(f"CALDAV: Неизвестный UTC-сдвиг: {tz}")
-        tz = 3
 
-    return dt.astimezone(tz).strftime("%y-%m-%d %H:%M")
+def _format_changes_for_timezone(
+    changes: list,
+    target_timezone: tzinfo,
+) -> list[str]:
+    formatted: list[str] = []
+    for change in changes:
+        if not isinstance(change, list):
+            formatted.append(str(change))
+            continue
+
+        old_due = change[0] if change[0] else "—"
+        new_due = change[1] if change[1] else "—"
+        if isinstance(old_due, datetime):
+            old_due = format_to_timezone(old_due, target_timezone)
+        if isinstance(new_due, datetime):
+            new_due = format_to_timezone(new_due, target_timezone)
+        formatted.append(f"Due: `{old_due or '—'}` → `{new_due or '—'}`")
+    return formatted
 
 def change_description(old_description, new_description):
     """
@@ -364,8 +382,11 @@ def poll_new_tasks():
                                     callback_data=f"move:{item['board_id']}:{item['stack_id']}:{card_id}:{next_stack_id}"
                                 ))
 
-                            need_zone = get_timezone(tg_id)
-                            duedat = item['duedate'].dt if item['duedate'] else "—"
+                            need_zone = get_effective_timezone(
+                                tg_id,
+                                default_tzid=TIMEZONE,
+                            )
+                            duedat = item['duedate'] or "—"
                             if isinstance(duedat, datetime):
                                 duedat_str = format_to_timezone(duedat, tz=need_zone) if duedat else "—"
                             else:
@@ -406,43 +427,32 @@ def poll_new_tasks():
                     kb = InlineKeyboardMarkup()
                     kb.add(InlineKeyboardButton(text="Открыть на клауде", url=card_url(item["board_id"], card_id)))
                     for tg_id in tg_ids:
-                        need_zone = get_timezone(tg_id)
-                        for i in range(len(changes)):
-                            if isinstance(changes[i], list):
-                                od = changes[i][0].dt if changes[i][0] else "—"
-                                if isinstance(od, datetime):
-                                    od = format_to_timezone(od, tz=need_zone) if od else "—"
-                                else:
-                                    od = str(od)
-
-                                nd = changes[i][1].dt if changes[i][1] else "—"
-                                if isinstance(nd, datetime):
-                                    nd = format_to_timezone(nd, tz=need_zone) if nd else "—"
-                                else:
-                                    nd = str(nd)
-                                changes[i] = f"Due: `{od or '—'}` → `{nd or '—'}`"
+                        need_zone = get_effective_timezone(
+                            tg_id,
+                            default_tzid=TIMEZONE,
+                        )
+                        user_changes = _format_changes_for_timezone(
+                            changes,
+                            need_zone,
+                        )
                         send_message_limited(
                             tg_id,
-                            f"✏️ *Изменения в карточке* «{item['title']}» (ID {cid_link}):\n" + "\n".join(changes),
+                            f"✏️ *Изменения в карточке* «{item['title']}» "
+                            f"(ID {cid_link}):\n" + "\n".join(user_changes),
                             reply_markup=kb,
                         )
 
-                    for i in range(len(changes)):
-                        if isinstance(changes[i], list):
-                            od = changes[i][0].dt if changes[i][0] else "—"
-                            if isinstance(od, datetime):
-                                od = format_to_timezone(od, tz=3) if od else "—"
-                            else:
-                                od = str(od)
-
-                            nd = changes[i][1].dt if changes[i][1] else "—"
-                            if isinstance(nd, datetime):
-                                nd = format_to_timezone(nd, tz=3) if nd else "—"
-                            else:
-                                nd = str(nd)
-                            changes[i] = f"Due: `{od or '—'}` → `{nd or '—'}`"
+                    team_zone = get_effective_timezone(
+                        None,
+                        default_tzid=TIMEZONE,
+                    )
+                    team_changes = _format_changes_for_timezone(
+                        changes,
+                        team_zone,
+                    )
                     send_log(
-                        f"✏️ *Изменения в карточке* «{item['title']}»:\n" + "\n".join(changes),
+                        f"✏️ *Изменения в карточке* «{item['title']}»:\n"
+                        + "\n".join(team_changes),
                         board_id=item['board_id'],
                         reply_markup=kb,
                     )

--- a/source/timezone.py
+++ b/source/timezone.py
@@ -1,0 +1,56 @@
+"""Resolve application timezones from IANA timezone identifiers."""
+
+from dataclasses import dataclass
+from datetime import UTC, tzinfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+@dataclass(frozen=True, slots=True)
+class TimezoneSettings:
+    """Timezone values supplied by Nextcloud and the user."""
+
+    nextcloud_tzid: str | None = None
+    override_tzid: str | None = None
+
+
+def normalize_tzid(value: object) -> str | None:
+    """Return a trimmed IANA identifier or None for invalid input."""
+
+    if not isinstance(value, str):
+        return None
+
+    tzid = value.strip()
+    if not tzid:
+        return None
+
+    try:
+        ZoneInfo(tzid)
+    except (OSError, ValueError, ZoneInfoNotFoundError):
+        return None
+
+    return tzid
+
+
+def _load_timezone(value: object) -> ZoneInfo | None:
+    normalized = normalize_tzid(value)
+    return ZoneInfo(normalized) if normalized is not None else None
+
+
+def resolve_effective_timezone(
+    settings: TimezoneSettings,
+    *,
+    default_tzid: str,
+) -> tzinfo:
+    """Resolve override, Nextcloud, default, then UTC in that order."""
+
+    candidates = (
+        settings.override_tzid,
+        settings.nextcloud_tzid,
+        default_tzid,
+    )
+    for candidate in candidates:
+        resolved = _load_timezone(candidate)
+        if resolved is not None:
+            return resolved
+
+    return UTC

--- a/source/timezone_command.py
+++ b/source/timezone_command.py
@@ -1,0 +1,35 @@
+"""Application logic for the Telegram /timezone command."""
+
+from collections.abc import Callable
+
+from source.timezone import normalize_tzid
+
+TIMEZONE_HELP = (
+    "Формат: /timezone <IANA timezone|auto>\n"
+    "Примеры: /timezone Europe/Warsaw, "
+    "/timezone Europe/Moscow, /timezone auto"
+)
+
+
+class InvalidTimezoneInput(ValueError):
+    """Raised when a command argument is not a valid IANA timezone."""
+
+
+def apply_timezone_argument(
+    argument: str,
+    *,
+    save_override: Callable[[str], None],
+    clear_override: Callable[[], None],
+) -> str:
+    """Apply a validated command argument through local DB callbacks."""
+    value = argument.strip()
+    if value.casefold() == "auto":
+        clear_override()
+        return "Автоматическая timezone из Nextcloud снова включена."
+
+    tzid = normalize_tzid(value)
+    if tzid is None:
+        raise InvalidTimezoneInput(value)
+
+    save_override(tzid)
+    return f"Timezone изменена на {tzid}."

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the Telegram bot."""

--- a/tests/caldav_fakes.py
+++ b/tests/caldav_fakes.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date, datetime
 from typing import ClassVar
 from unittest.mock import Mock
 
@@ -23,7 +23,8 @@ class FrozenDateTime(datetime):
 
 @dataclass(frozen=True)
 class DateProperty:
-    dt: datetime
+    dt: datetime | date
+    params: dict[str, object] = field(default_factory=dict)
 
 
 class FakeComponent:
@@ -82,6 +83,7 @@ class FakeCalendar:
         self.error = error
         self.name = name
         self.expand_calls: list[bool] = []
+        self.search_calls: list[tuple[object, object]] = []
 
     def date_search(
         self,
@@ -91,6 +93,7 @@ class FakeCalendar:
         expand: bool = False,
     ) -> list[FakeEvent]:
         self.expand_calls.append(expand)
+        self.search_calls.append((start, end))
         if self.error is not None:
             raise self.error
 
@@ -190,18 +193,22 @@ def make_poll_event(
     *,
     event_uid: str,
     summary: str,
-    start: datetime,
-    end: datetime,
+    start: datetime | date,
+    end: datetime | date,
     participants: list[dict[str, object]],
     ical_attendees: FakeAttendee | list[FakeAttendee] | None = None,
+    start_tzid: str | None = None,
+    end_tzid: str | None = None,
 ) -> FakeEvent:
+    start_params = {"TZID": start_tzid} if start_tzid is not None else {}
+    end_params = {"TZID": end_tzid} if end_tzid is not None else {}
     values = {
         "UID": event_uid,
         "SUMMARY": summary,
         "DESCRIPTION": "Weekly team sync",
         "LOCATION": "Online",
-        "DTSTART": DateProperty(start),
-        "DTEND": DateProperty(end),
+        "DTSTART": DateProperty(start, start_params),
+        "DTEND": DateProperty(end, end_params),
     }
     if ical_attendees is not None:
         values["ATTENDEE"] = ical_attendees

--- a/tests/caldav_fakes.py
+++ b/tests/caldav_fakes.py
@@ -1,0 +1,210 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import ClassVar
+from unittest.mock import Mock
+
+from source.caldav_notification_state import SentEventKey
+
+
+class StopPolling(Exception):
+    pass
+
+
+class FrozenDateTime(datetime):
+    current: ClassVar["FrozenDateTime"]
+
+    @classmethod
+    def now(cls, tz=None):
+        if tz is None:
+            return cls.current.replace(tzinfo=None)
+
+        return cls.current.astimezone(tz)
+
+
+@dataclass(frozen=True)
+class DateProperty:
+    dt: datetime
+
+
+class FakeComponent:
+    name = "VEVENT"
+
+    def __init__(
+        self,
+        values: dict[str, object],
+        *,
+        participants: list[dict[str, object]] | None = None,
+    ) -> None:
+        self._values = {key.upper(): value for key, value in values.items()}
+        self.participants = participants or []
+
+    def get(self, key: str, default=None):
+        return self._values.get(key.upper(), default)
+
+
+class FakeICalendar:
+    def __init__(self, components: list[FakeComponent]) -> None:
+        self.components = components
+
+    def walk(self, name: str | None = None) -> list[FakeComponent]:
+        if name is None:
+            return list(self.components)
+
+        return [
+            component
+            for component in self.components
+            if component.name == name.upper()
+        ]
+
+
+class FakeEvent:
+    def __init__(
+        self,
+        calendar_data: FakeICalendar,
+        *,
+        url: str = "https://calendar.test/event.ics",
+    ) -> None:
+        self.data = calendar_data
+        self.url = url
+        self.icalendar_instance = calendar_data
+        self.save = Mock()
+
+
+class FakeCalendar:
+    def __init__(
+        self,
+        events: list[FakeEvent] | None = None,
+        *,
+        error: Exception | None = None,
+        name: str = "Team",
+    ) -> None:
+        self.events = events or []
+        self.error = error
+        self.name = name
+        self.expand_calls: list[bool] = []
+
+    def date_search(
+        self,
+        *,
+        start: object,
+        end: object,
+        expand: bool = False,
+    ) -> list[FakeEvent]:
+        self.expand_calls.append(expand)
+        if self.error is not None:
+            raise self.error
+
+        return list(self.events)
+
+
+class FakePrincipal:
+    def __init__(self, calendars: list[FakeCalendar]) -> None:
+        self._calendars = calendars
+
+    def calendars(self) -> list[FakeCalendar]:
+        return list(self._calendars)
+
+
+class FakeClient:
+    def __init__(self, principal: FakePrincipal) -> None:
+        self._principal = principal
+
+    def principal(self) -> FakePrincipal:
+        return self._principal
+
+
+class FakeCalendarParser:
+    @staticmethod
+    def from_ical(data: FakeICalendar) -> FakeICalendar:
+        return data
+
+
+class FakeInlineKeyboardButton:
+    def __init__(
+        self,
+        text: str,
+        *,
+        style: str | None = None,
+        callback_data: str | None = None,
+    ) -> None:
+        self.text = text
+        self.style = style
+        self.callback_data = callback_data
+
+
+class FakeInlineKeyboardMarkup:
+    def __init__(self) -> None:
+        self.rows: list[tuple[FakeInlineKeyboardButton, ...]] = []
+
+    def row(self, *buttons: FakeInlineKeyboardButton) -> None:
+        self.rows.append(buttons)
+
+
+class FakeLogger:
+    def _ignore(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    debug = _ignore
+    error = _ignore
+    exception = _ignore
+    info = _ignore
+    warning = _ignore
+
+
+class FakeAttendee:
+    def __init__(self, email: str) -> None:
+        self.email = email
+        self.params = {
+            "PARTSTAT": ["NEEDS-ACTION"],
+            "RSVP": ["TRUE"],
+        }
+
+    def __str__(self) -> str:
+        return f"mailto:{self.email}"
+
+
+@dataclass
+class InMemoryNotificationState:
+    keys: set[SentEventKey] = field(default_factory=set)
+    saved: list[SentEventKey] = field(default_factory=list)
+    deleted: list[SentEventKey] = field(default_factory=list)
+
+    def load(self) -> set[SentEventKey]:
+        return set(self.keys)
+
+    def save(
+        self,
+        _name: str,
+        key: SentEventKey,
+        _url: str,
+    ) -> None:
+        self.keys.add(key)
+        self.saved.append(key)
+
+    def delete(self, key: SentEventKey) -> None:
+        self.keys.discard(key)
+        self.deleted.append(key)
+
+
+def make_poll_event(
+    *,
+    event_uid: str,
+    summary: str,
+    start: datetime,
+    end: datetime,
+    participants: list[dict[str, object]],
+    ical_attendees: FakeAttendee | list[FakeAttendee] | None = None,
+) -> FakeEvent:
+    values = {
+        "UID": event_uid,
+        "SUMMARY": summary,
+        "DESCRIPTION": "Weekly team sync",
+        "LOCATION": "Online",
+        "DTSTART": DateProperty(start),
+        "DTEND": DateProperty(end),
+    }
+    if ical_attendees is not None:
+        values["ATTENDEE"] = ical_attendees
+
+    component = FakeComponent(values, participants=participants)
+    return FakeEvent(FakeICalendar([component]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+
+ENV_DEFAULTS = {
+    "BASE_URL": "https://nextcloud.example.test",
+    "BOT_TOKEN": "123:test",
+    "MYSQL_DB": "test",
+    "MYSQL_PASS": "test",
+    "MYSQL_USER": "test",
+    "NEXTCLOUD_PASS": "test",
+    "NEXTCLOUD_USER": "test",
+    "WEB_APP_URL": "https://nextcloud.example.test",
+}
+
+for name, value in ENV_DEFAULTS.items():
+    os.environ.setdefault(name, value)

--- a/tests/test_caldav_notification_state.py
+++ b/tests/test_caldav_notification_state.py
@@ -1,0 +1,38 @@
+from source.caldav_notification_state import SentEventKey, find_stale_keys
+
+
+def test_find_stale_keys_returns_unobserved_keys() -> None:
+    stale_key = SentEventKey(
+        telegram_id=101,
+        cooldown_minutes=60,
+        event_uid="team_sync_2026_instance",
+    )
+    observed_key = SentEventKey(
+        telegram_id=202,
+        cooldown_minutes=60,
+        event_uid="team_sync_2026_instance",
+    )
+
+    result = find_stale_keys(
+        {stale_key, observed_key},
+        {observed_key},
+        scan_complete=True,
+    )
+
+    assert result == {stale_key}
+
+
+def test_find_stale_keys_preserves_state_after_incomplete_scan() -> None:
+    saved_key = SentEventKey(
+        telegram_id=101,
+        cooldown_minutes=60,
+        event_uid="team_sync_2026_instance",
+    )
+
+    result = find_stale_keys(
+        {saved_key},
+        set(),
+        scan_complete=False,
+    )
+
+    assert result == set()

--- a/tests/test_caldav_polling.py
+++ b/tests/test_caldav_polling.py
@@ -3,9 +3,10 @@ import importlib
 import inspect
 import sys
 import textwrap
-from datetime import timedelta, timezone
+from datetime import timedelta
 from types import ModuleType
 from unittest.mock import Mock
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -66,7 +67,6 @@ def nc_calendar(monkeypatch: pytest.MonkeyPatch):
         CALDAV_USERNAME="caldav-user",
         CALDAV_PASSWORD="caldav-password",
         CALDAV_COOLDOWNS={"Team": [COOLDOWN]},
-        TIMEZONES={3: timezone(timedelta(hours=3))},
     )
     sender = _module(
         "source.connections.sender",
@@ -74,9 +74,12 @@ def nc_calendar(monkeypatch: pytest.MonkeyPatch):
     )
     users = _module(
         "source.db.repos.users",
+        NEXTCLOUD_FIELD_MISSING=object(),
+        get_effective_timezone=lambda _telegram_id, **_kwargs: ZoneInfo(
+            "Europe/Moscow"
+        ),
         get_tg_id_by_email=lambda _email: None,
-        save_email_by_username=_ignore,
-        get_timezone=lambda _telegram_id: 3,
+        update_nextcloud_profile=_ignore,
     )
     repository = _module(
         "source.db.repos.caldav_calendar",
@@ -98,6 +101,8 @@ def nc_calendar(monkeypatch: pytest.MonkeyPatch):
         vText=lambda value: value,
     )
 
+    requests = ModuleType("requests")
+    requests.get = _ignore
     modules = {
         "source.config": config,
         "source.connections.sender": sender,
@@ -108,7 +113,7 @@ def nc_calendar(monkeypatch: pytest.MonkeyPatch):
         "telebot.types": telebot_types,
         "caldav": caldav,
         "icalendar": icalendar,
-        "requests": ModuleType("requests"),
+        "requests": requests,
     }
     for name, module in modules.items():
         monkeypatch.setitem(sys.modules, name, module)
@@ -161,7 +166,9 @@ def _run_poll_cycle(
     principal = FakePrincipal(calendars)
     sender = sender or Mock()
     mutator = mutator or Mock()
-    timezone_getter = timezone_getter or Mock(return_value=3)
+    timezone_getter = timezone_getter or Mock(
+        return_value=ZoneInfo("Europe/Moscow")
+    )
 
     def stop_polling(_seconds: int) -> None:
         raise StopPolling
@@ -180,7 +187,11 @@ def _run_poll_cycle(
         "get_tg_id_by_email",
         (identities or {}).get,
     )
-    monkeypatch.setattr(nc_calendar, "get_timezone", timezone_getter)
+    monkeypatch.setattr(
+        nc_calendar,
+        "get_effective_timezone",
+        timezone_getter,
+    )
     monkeypatch.setattr(
         nc_calendar,
         "format_to_timezone",

--- a/tests/test_caldav_polling.py
+++ b/tests/test_caldav_polling.py
@@ -1,0 +1,547 @@
+import ast
+import importlib
+import inspect
+import sys
+import textwrap
+from datetime import timedelta, timezone
+from types import ModuleType
+from unittest.mock import Mock
+
+import pytest
+
+from source.caldav_notification_state import SentEventKey
+from tests.caldav_fakes import (
+    FakeAttendee,
+    FakeCalendar,
+    FakeCalendarParser,
+    FakeClient,
+    FakeComponent,
+    FakeEvent,
+    FakeICalendar,
+    FakeInlineKeyboardButton,
+    FakeInlineKeyboardMarkup,
+    FakeLogger,
+    FakePrincipal,
+    FrozenDateTime,
+    InMemoryNotificationState,
+    StopPolling,
+    make_poll_event,
+)
+
+EVENT_UID = "team_sync_2026"
+USER_EMAIL = "user@example.com"
+USER_ID = 101
+COOLDOWN = 60
+
+
+def _module(name: str, **attributes: object) -> ModuleType:
+    module = ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    return module
+
+
+def _empty_keys() -> set[SentEventKey]:
+    return set()
+
+
+def _ignore(*_args: object, **_kwargs: object) -> None:
+    pass
+
+
+@pytest.fixture
+def nc_calendar(monkeypatch: pytest.MonkeyPatch):
+    config = _module(
+        "source.config",
+        WEB_CALDAV_URL="https://calendar.test/caldav",
+        USERNAME="nextcloud-user",
+        PASSWORD="nextcloud-password",
+        COOLDOWN_TUESDAY=2,
+        COOLDOWN_SUNDAY=10,
+        COOLDOWN_DEFAULT=2,
+        POLL_INTERVAL=60,
+        WEB_APP_URL="https://nextcloud.test",
+        UPDATE_INTERVAL=1,
+        TIMEZONE="Europe/Moscow",
+        CALDAV_USERNAME="caldav-user",
+        CALDAV_PASSWORD="caldav-password",
+        CALDAV_COOLDOWNS={"Team": [COOLDOWN]},
+        TIMEZONES={3: timezone(timedelta(hours=3))},
+    )
+    sender = _module(
+        "source.connections.sender",
+        send_message_limited=_ignore,
+    )
+    users = _module(
+        "source.db.repos.users",
+        get_tg_id_by_email=lambda _email: None,
+        save_email_by_username=_ignore,
+        get_timezone=lambda _telegram_id: 3,
+    )
+    repository = _module(
+        "source.db.repos.caldav_calendar",
+        delete_sent_event=_ignore,
+        get_sent_event_keys=_empty_keys,
+        save_event_send=_ignore,
+    )
+    app_logging = _module("source.app_logging", logger=FakeLogger())
+    telebot_types = _module(
+        "telebot.types",
+        InlineKeyboardMarkup=FakeInlineKeyboardMarkup,
+        InlineKeyboardButton=FakeInlineKeyboardButton,
+    )
+    telebot = _module("telebot", types=telebot_types)
+    caldav = _module("caldav", DAVClient=None, error=Exception)
+    icalendar = _module(
+        "icalendar",
+        Calendar=FakeCalendarParser,
+        vText=lambda value: value,
+    )
+
+    modules = {
+        "source.config": config,
+        "source.connections.sender": sender,
+        "source.db.repos.users": users,
+        "source.db.repos.caldav_calendar": repository,
+        "source.app_logging": app_logging,
+        "telebot": telebot,
+        "telebot.types": telebot_types,
+        "caldav": caldav,
+        "icalendar": icalendar,
+        "requests": ModuleType("requests"),
+    }
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    monkeypatch.delitem(sys.modules, "source.nc_calendar", raising=False)
+    module = importlib.import_module("source.nc_calendar")
+    yield module
+    sys.modules.pop("source.nc_calendar", None)
+
+
+def _key(
+    telegram_id: int = USER_ID,
+    cooldown: int = COOLDOWN,
+    event_uid: str = EVENT_UID,
+) -> SentEventKey:
+    return SentEventKey(
+        telegram_id=telegram_id,
+        cooldown_minutes=cooldown,
+        event_uid=event_uid,
+    )
+
+
+def _participant(
+    email: str = USER_EMAIL,
+    *,
+    status: str = "NEEDS-ACTION",
+) -> dict[str, object]:
+    return {
+        "email": email,
+        "name": email.split("@", maxsplit=1)[0],
+        "role": "ATTENDEE",
+        "status": status,
+    }
+
+
+def _run_poll_cycle(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    state: InMemoryNotificationState,
+    calendars: list[FakeCalendar],
+    now: FrozenDateTime,
+    identities: dict[str, int] | None = None,
+    cooldowns: list[int] | None = None,
+    sender: Mock | None = None,
+    mutator: Mock | None = None,
+) -> tuple[Mock, Mock]:
+    FrozenDateTime.current = now
+    principal = FakePrincipal(calendars)
+    sender = sender or Mock()
+    mutator = mutator or Mock()
+
+    def stop_polling(_seconds: int) -> None:
+        raise StopPolling
+
+    monkeypatch.setattr(nc_calendar, "datetime", FrozenDateTime)
+    monkeypatch.setattr(
+        nc_calendar,
+        "DAVClient",
+        lambda *_args, **_kwargs: FakeClient(principal),
+    )
+    monkeypatch.setattr(nc_calendar, "get_sent_event_keys", state.load)
+    monkeypatch.setattr(nc_calendar, "save_event_send", state.save)
+    monkeypatch.setattr(nc_calendar, "delete_sent_event", state.delete)
+    monkeypatch.setattr(
+        nc_calendar,
+        "get_tg_id_by_email",
+        (identities or {}).get,
+    )
+    monkeypatch.setattr(nc_calendar, "get_timezone", lambda _id: 3)
+    monkeypatch.setattr(
+        nc_calendar,
+        "format_to_timezone",
+        lambda _value, tz: "19:00",
+    )
+    monkeypatch.setattr(
+        nc_calendar,
+        "get_all_participants",
+        lambda component: component.participants,
+    )
+    monkeypatch.setattr(nc_calendar, "send_message_limited", sender)
+    monkeypatch.setattr(nc_calendar, "sleep", stop_polling)
+    monkeypatch.setattr(
+        nc_calendar,
+        "CALDAV_COOLDOWNS",
+        {"Team": cooldowns or [COOLDOWN]},
+    )
+    monkeypatch.setattr(
+        nc_calendar,
+        "set_all_attendees_needs_action",
+        mutator,
+        raising=False,
+    )
+
+    with pytest.raises(StopPolling):
+        nc_calendar.poll_events()
+
+    return sender, mutator
+
+
+def _weekly_event(
+    now: FrozenDateTime,
+    *,
+    event_uid: str = EVENT_UID,
+    email: str = USER_EMAIL,
+) -> FakeEvent:
+    return make_poll_event(
+        event_uid=event_uid,
+        summary="Team sync",
+        start=now + timedelta(minutes=30),
+        end=now + timedelta(minutes=90),
+        participants=[_participant(email)],
+    )
+
+
+def test_stale_cleanup_does_not_mutate_caldav(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = InMemoryNotificationState({_key()})
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    attendee = FakeAttendee(USER_EMAIL)
+    original_params = {
+        name: list(values) for name, values in attendee.params.items()
+    }
+    unrelated_event = make_poll_event(
+        event_uid="unrelated-event",
+        summary="Other event",
+        start=now + timedelta(minutes=30),
+        end=now + timedelta(minutes=90),
+        participants=[],
+        ical_attendees=attendee,
+    )
+    calendar = FakeCalendar([unrelated_event])
+    mutator = Mock()
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[calendar],
+        now=now,
+        mutator=mutator,
+    )
+
+    assert state.deleted == [_key()]
+    mutator.assert_not_called()
+    unrelated_event.save.assert_not_called()
+    assert attendee.params == original_params
+    assert calendar.expand_calls == [False]
+
+
+def test_stale_notification_is_deleted_from_local_state(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = _key()
+    state = InMemoryNotificationState({key})
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar()],
+        now=now,
+    )
+
+    assert state.keys == set()
+    assert state.deleted == [key]
+
+
+def test_observed_notification_is_not_deleted(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = _key()
+    state = InMemoryNotificationState({key})
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    event = _weekly_event(now)
+    sender = Mock()
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        identities={USER_EMAIL: USER_ID},
+        sender=sender,
+    )
+
+    assert state.keys == {key}
+    assert state.deleted == []
+    sender.assert_not_called()
+    event.save.assert_not_called()
+
+
+def test_incomplete_caldav_scan_preserves_local_state(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = _key()
+    state = InMemoryNotificationState({key})
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    mutator = Mock()
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[
+            FakeCalendar(),
+            FakeCalendar(error=RuntimeError("calendar unavailable")),
+        ],
+        now=now,
+        mutator=mutator,
+    )
+
+    assert state.keys == {key}
+    assert state.deleted == []
+    mutator.assert_not_called()
+
+
+def test_cleanup_deletes_only_stale_user_record(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stale_key = _key(telegram_id=101)
+    newly_sent_key = _key(telegram_id=202)
+    other_cooldown_key = _key(telegram_id=202, cooldown=15)
+    state = InMemoryNotificationState({stale_key, other_cooldown_key})
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    event = _weekly_event(now, email="second@example.com")
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        identities={"second@example.com": 202},
+        cooldowns=[COOLDOWN, 15],
+    )
+
+    assert state.deleted == [stale_key]
+    assert state.saved == [newly_sent_key]
+    assert state.keys == {newly_sent_key, other_cooldown_key}
+
+
+def test_event_uid_with_underscores_is_not_truncated(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = _key(event_uid="team_sync_2026_instance")
+    state = InMemoryNotificationState({key})
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar()],
+        now=now,
+    )
+
+    assert state.deleted == [key]
+    assert state.deleted[0].event_uid == "team_sync_2026_instance"
+
+
+def test_next_weekly_occurrence_can_be_notified_after_cleanup(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = InMemoryNotificationState()
+    sender = Mock()
+    mutator = Mock()
+    first_week = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    first_event = _weekly_event(first_week)
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([first_event])],
+        now=first_week,
+        identities={USER_EMAIL: USER_ID},
+        sender=sender,
+        mutator=mutator,
+    )
+
+    assert sender.call_count == 1
+    assert state.saved == [_key()]
+    assert state.deleted == []
+    assert state.keys == {_key()}
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar()],
+        now=first_week + timedelta(days=1),
+        sender=sender,
+        mutator=mutator,
+    )
+
+    assert sender.call_count == 1
+    assert state.saved == [_key()]
+    assert state.deleted == [_key()]
+    assert state.keys == set()
+
+    second_week = first_week + timedelta(days=7)
+    second_event = _weekly_event(second_week)
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([second_event])],
+        now=second_week,
+        identities={USER_EMAIL: USER_ID},
+        sender=sender,
+        mutator=mutator,
+    )
+
+    assert sender.call_count == 2
+    assert state.saved == [_key(), _key()]
+    assert state.deleted == [_key()]
+    assert state.keys == {_key()}
+    mutator.assert_not_called()
+    first_event.save.assert_not_called()
+    second_event.save.assert_not_called()
+
+
+def test_explicit_partstat_update_still_saves_event(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    FrozenDateTime.current = now
+    attendee = FakeAttendee(USER_EMAIL)
+    component = FakeComponent(
+        {
+            "UID": EVENT_UID,
+            "ATTENDEE": attendee,
+        }
+    )
+    event = FakeEvent(FakeICalendar([component]))
+    calendar = FakeCalendar([event])
+    principal = FakePrincipal([calendar])
+
+    monkeypatch.setattr(nc_calendar, "datetime", FrozenDateTime)
+    monkeypatch.setattr(
+        nc_calendar,
+        "DAVClient",
+        lambda *_args, **_kwargs: FakeClient(principal),
+    )
+
+    result = nc_calendar.update_event_partstat(
+        EVENT_UID,
+        USER_EMAIL,
+        "accepted",
+    )
+
+    assert result is True
+    assert attendee.params["PARTSTAT"] == ["ACCEPTED"]
+    assert attendee.params["RSVP"] == ["FALSE"]
+    event.save.assert_called_once_with()
+    assert calendar.expand_calls == [True]
+
+
+def test_periodic_poller_has_no_caldav_write_calls(
+    nc_calendar: ModuleType,
+) -> None:
+    source = textwrap.dedent(inspect.getsource(nc_calendar.poll_events))
+    tree = ast.parse(source)
+    called_names = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    called_attributes = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+
+    assert "set_all_attendees_needs_action" not in called_names
+    assert called_attributes.isdisjoint({"put", "save"})

--- a/tests/test_caldav_polling.py
+++ b/tests/test_caldav_polling.py
@@ -155,11 +155,13 @@ def _run_poll_cycle(
     cooldowns: list[int] | None = None,
     sender: Mock | None = None,
     mutator: Mock | None = None,
+    timezone_getter: Mock | None = None,
 ) -> tuple[Mock, Mock]:
     FrozenDateTime.current = now
     principal = FakePrincipal(calendars)
     sender = sender or Mock()
     mutator = mutator or Mock()
+    timezone_getter = timezone_getter or Mock(return_value=3)
 
     def stop_polling(_seconds: int) -> None:
         raise StopPolling
@@ -178,7 +180,7 @@ def _run_poll_cycle(
         "get_tg_id_by_email",
         (identities or {}).get,
     )
-    monkeypatch.setattr(nc_calendar, "get_timezone", lambda _id: 3)
+    monkeypatch.setattr(nc_calendar, "get_timezone", timezone_getter)
     monkeypatch.setattr(
         nc_calendar,
         "format_to_timezone",
@@ -308,6 +310,7 @@ def test_observed_notification_is_not_deleted(
     )
     event = _weekly_event(now)
     sender = Mock()
+    timezone_getter = Mock(return_value=3)
 
     _run_poll_cycle(
         nc_calendar,
@@ -317,11 +320,46 @@ def test_observed_notification_is_not_deleted(
         now=now,
         identities={USER_EMAIL: USER_ID},
         sender=sender,
+        timezone_getter=timezone_getter,
     )
 
     assert state.keys == {key}
     assert state.deleted == []
     sender.assert_not_called()
+    timezone_getter.assert_not_called()
+    event.save.assert_not_called()
+
+
+def test_participant_without_telegram_id_is_skipped(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = InMemoryNotificationState()
+    now = FrozenDateTime(
+        2026,
+        8,
+        6,
+        18,
+        tzinfo=nc_calendar.TEAM_TZ,
+    )
+    event = _weekly_event(now, email="unknown@example.com")
+    sender = Mock()
+    timezone_getter = Mock(return_value=3)
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        sender=sender,
+        timezone_getter=timezone_getter,
+    )
+
+    assert state.keys == set()
+    assert state.saved == []
+    sender.assert_not_called()
+    timezone_getter.assert_not_called()
     event.save.assert_not_called()
 
 

--- a/tests/test_caldav_polling.py
+++ b/tests/test_caldav_polling.py
@@ -3,7 +3,7 @@ import importlib
 import inspect
 import sys
 import textwrap
-from datetime import timedelta
+from datetime import UTC, date, datetime, timedelta
 from types import ModuleType
 from unittest.mock import Mock
 from zoneinfo import ZoneInfo
@@ -194,11 +194,6 @@ def _run_poll_cycle(
     )
     monkeypatch.setattr(
         nc_calendar,
-        "format_to_timezone",
-        lambda _value, tz: "19:00",
-    )
-    monkeypatch.setattr(
-        nc_calendar,
         "get_all_participants",
         lambda component: component.participants,
     )
@@ -237,11 +232,314 @@ def _weekly_event(
     )
 
 
-def test_stale_cleanup_does_not_mutate_caldav(
+def test_poll_window_is_an_absolute_24_hour_interval(
     nc_calendar: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    state = InMemoryNotificationState({_key()})
+    state = InMemoryNotificationState()
+    calendar = FakeCalendar()
+    now = FrozenDateTime(
+        2026,
+        3,
+        29,
+        1,
+        30,
+        tzinfo=ZoneInfo("Europe/Warsaw"),
+    )
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[calendar],
+        now=now,
+    )
+
+    start, end = calendar.search_calls[0]
+    assert isinstance(start, datetime)
+    assert isinstance(end, datetime)
+    assert start.tzinfo == UTC
+    assert end - start == timedelta(hours=24)
+
+
+def test_calendar_message_uses_localized_weekday_and_time(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = InMemoryNotificationState()
+    sender = Mock()
+    now = FrozenDateTime(2026, 8, 10, 22, tzinfo=UTC)
+    event = _weekly_event(now)
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        identities={USER_EMAIL: USER_ID},
+        sender=sender,
+        timezone_getter=Mock(return_value=ZoneInfo("Europe/Warsaw")),
+    )
+
+    message = sender.call_args.args[1]
+    assert nc_calendar.WEEKDAY_RU[1] in message
+    assert "Начало: 2026-08-11 00:30" in message
+    assert "Конец: 2026-08-11 01:30" in message
+
+
+def test_localized_weekday_changes_after_midnight(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = InMemoryNotificationState()
+    sender = Mock()
+    now = FrozenDateTime(2026, 8, 10, 22, tzinfo=UTC)
+    event = _weekly_event(now)
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        identities={USER_EMAIL: USER_ID},
+        sender=sender,
+        timezone_getter=Mock(return_value=ZoneInfo("Europe/Warsaw")),
+    )
+
+    message = sender.call_args.args[1]
+    assert nc_calendar.WEEKDAY_RU[1] in message
+    assert nc_calendar.WEEKDAY_RU[0] not in message
+
+
+def test_poll_cooldown_uses_recipient_zone_for_floating_start(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = InMemoryNotificationState()
+    sender = Mock()
+    now = FrozenDateTime(2026, 10, 25, 7, 30, tzinfo=UTC)
+    event = make_poll_event(
+        event_uid=EVENT_UID,
+        summary="Team sync",
+        start=FrozenDateTime(2026, 10, 25, 9),
+        end=FrozenDateTime(2026, 10, 25, 10),
+        participants=[_participant()],
+    )
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        identities={USER_EMAIL: USER_ID},
+        sender=sender,
+        timezone_getter=Mock(return_value=ZoneInfo("Europe/Warsaw")),
+    )
+
+    sender.assert_called_once()
+    assert state.saved == [_key()]
+
+
+def test_floating_event_is_evaluated_separately_for_each_attendee(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warsaw_id = 101
+    moscow_id = 202
+    warsaw_email = "warsaw@example.com"
+    moscow_email = "moscow@example.com"
+    state = InMemoryNotificationState()
+    sender = Mock()
+    now = FrozenDateTime(2026, 10, 25, 5, 30, tzinfo=UTC)
+    event = make_poll_event(
+        event_uid=EVENT_UID,
+        summary="Team sync",
+        start=FrozenDateTime(2026, 10, 25, 9),
+        end=FrozenDateTime(2026, 10, 25, 10),
+        participants=[
+            _participant(warsaw_email),
+            _participant(moscow_email),
+        ],
+    )
+    zones = {
+        warsaw_id: ZoneInfo("Europe/Warsaw"),
+        moscow_id: ZoneInfo("Europe/Moscow"),
+    }
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        identities={
+            warsaw_email: warsaw_id,
+            moscow_email: moscow_id,
+        },
+        cooldowns=[60, 180],
+        sender=sender,
+        timezone_getter=Mock(
+            side_effect=lambda telegram_id, **_kwargs: zones[telegram_id]
+        ),
+    )
+
+    assert sender.call_count == 2
+    assert [call.args[0] for call in sender.call_args_list] == [
+        warsaw_id,
+        moscow_id,
+    ]
+    assert all(
+        "Начало: 2026-10-25 09:00" in call.args[1]
+        for call in sender.call_args_list
+    )
+    assert state.saved == [
+        _key(telegram_id=warsaw_id, cooldown=180),
+        _key(telegram_id=moscow_id, cooldown=60),
+    ]
+
+
+def test_time_localization_failure_preserves_notification_state(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = _key(event_uid="stale-event")
+    state = InMemoryNotificationState({key})
+    sender = Mock()
+    now = FrozenDateTime(2026, 8, 10, 8, 30, tzinfo=UTC)
+    event = make_poll_event(
+        event_uid=EVENT_UID,
+        summary="Team sync",
+        start=FrozenDateTime(2026, 8, 10, 9),
+        end=FrozenDateTime(2026, 8, 10, 10),
+        participants=[_participant()],
+        start_tzid="Unknown/Nowhere",
+    )
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        identities={USER_EMAIL: USER_ID},
+        sender=sender,
+        timezone_getter=Mock(return_value=ZoneInfo("Europe/Warsaw")),
+    )
+
+    assert state.keys == {key}
+    assert state.deleted == []
+    assert state.saved == []
+    sender.assert_not_called()
+    event.save.assert_not_called()
+
+
+def test_localization_failure_for_one_recipient_does_not_abort_others(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warsaw_id = 101
+    moscow_id = 202
+    warsaw_email = "warsaw@example.com"
+    moscow_email = "moscow@example.com"
+    stale_key = _key(event_uid="stale-event")
+    state = InMemoryNotificationState({stale_key})
+    sender = Mock()
+    now = FrozenDateTime(2026, 8, 10, 5, 30, tzinfo=UTC)
+    event = make_poll_event(
+        event_uid=EVENT_UID,
+        summary="Team sync",
+        start=FrozenDateTime(2026, 8, 10, 9),
+        end=FrozenDateTime(2026, 8, 10, 10),
+        participants=[
+            _participant(warsaw_email),
+            _participant(moscow_email),
+        ],
+    )
+    zones = {
+        warsaw_id: ZoneInfo("Europe/Warsaw"),
+        moscow_id: ZoneInfo("Europe/Moscow"),
+    }
+    localize_ical_value = nc_calendar.localize_ical_value
+
+    def localize_for_recipient(value, *, target_timezone, source_tzid):
+        if target_timezone == zones[warsaw_id]:
+            raise nc_calendar.UnknownSourceTimezoneError("Unknown/Nowhere")
+
+        return localize_ical_value(
+            value,
+            target_timezone=target_timezone,
+            source_tzid=source_tzid,
+        )
+
+    monkeypatch.setattr(
+        nc_calendar,
+        "localize_ical_value",
+        localize_for_recipient,
+    )
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        identities={
+            warsaw_email: warsaw_id,
+            moscow_email: moscow_id,
+        },
+        sender=sender,
+        timezone_getter=Mock(
+            side_effect=lambda telegram_id, **_kwargs: zones[telegram_id]
+        ),
+    )
+
+    sender.assert_called_once()
+    assert sender.call_args.args[0] == moscow_id
+    assert state.keys == {stale_key, _key(telegram_id=moscow_id)}
+    assert state.saved == [_key(telegram_id=moscow_id)]
+    assert state.deleted == []
+    event.save.assert_not_called()
+
+
+def test_periodic_poller_skips_all_day_event(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = InMemoryNotificationState()
+    sender = Mock()
+    timezone_getter = Mock(return_value=ZoneInfo("Europe/Warsaw"))
+    event = make_poll_event(
+        event_uid=EVENT_UID,
+        summary="Team sync",
+        start=date(2026, 8, 10),
+        end=date(2026, 8, 11),
+        participants=[_participant()],
+    )
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=FrozenDateTime(2026, 8, 10, tzinfo=UTC),
+        identities={USER_EMAIL: USER_ID},
+        sender=sender,
+        timezone_getter=timezone_getter,
+    )
+
+    timezone_getter.assert_not_called()
+    sender.assert_not_called()
+    event.save.assert_not_called()
+
+
+def test_periodic_polling_does_not_mutate_attendee_params(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = InMemoryNotificationState()
     now = FrozenDateTime(
         2026,
         8,
@@ -253,15 +551,15 @@ def test_stale_cleanup_does_not_mutate_caldav(
     original_params = {
         name: list(values) for name, values in attendee.params.items()
     }
-    unrelated_event = make_poll_event(
-        event_uid="unrelated-event",
-        summary="Other event",
+    event = make_poll_event(
+        event_uid=EVENT_UID,
+        summary="Team sync",
         start=now + timedelta(minutes=30),
         end=now + timedelta(minutes=90),
-        participants=[],
+        participants=[_participant()],
         ical_attendees=attendee,
     )
-    calendar = FakeCalendar([unrelated_event])
+    calendar = FakeCalendar([event])
     mutator = Mock()
 
     _run_poll_cycle(
@@ -270,14 +568,34 @@ def test_stale_cleanup_does_not_mutate_caldav(
         state=state,
         calendars=[calendar],
         now=now,
+        identities={USER_EMAIL: USER_ID},
         mutator=mutator,
     )
 
-    assert state.deleted == [_key()]
     mutator.assert_not_called()
-    unrelated_event.save.assert_not_called()
+    event.save.assert_not_called()
     assert attendee.params == original_params
     assert calendar.expand_calls == [False]
+
+
+def test_periodic_polling_still_does_not_save_calendar_event(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = InMemoryNotificationState()
+    now = FrozenDateTime(2026, 8, 6, 18, tzinfo=nc_calendar.TEAM_TZ)
+    event = _weekly_event(now)
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        identities={USER_EMAIL: USER_ID},
+    )
+
+    event.save.assert_not_called()
 
 
 def test_stale_notification_is_deleted_from_local_state(
@@ -321,7 +639,7 @@ def test_observed_notification_is_not_deleted(
     )
     event = _weekly_event(now)
     sender = Mock()
-    timezone_getter = Mock(return_value=3)
+    timezone_getter = Mock(return_value=ZoneInfo("Europe/Moscow"))
 
     _run_poll_cycle(
         nc_calendar,
@@ -337,8 +655,39 @@ def test_observed_notification_is_not_deleted(
     assert state.keys == {key}
     assert state.deleted == []
     sender.assert_not_called()
-    timezone_getter.assert_not_called()
+    timezone_getter.assert_called_once_with(
+        USER_ID,
+        default_tzid=nc_calendar.TIMEZONE,
+    )
     event.save.assert_not_called()
+
+
+def test_saved_same_uid_outside_cooldown_becomes_stale(
+    nc_calendar: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    key = _key()
+    state = InMemoryNotificationState({key})
+    now = FrozenDateTime(2026, 8, 6, 18, tzinfo=UTC)
+    event = make_poll_event(
+        event_uid=EVENT_UID,
+        summary="Team sync",
+        start=now + timedelta(hours=12),
+        end=now + timedelta(hours=13),
+        participants=[_participant()],
+    )
+
+    _run_poll_cycle(
+        nc_calendar,
+        monkeypatch,
+        state=state,
+        calendars=[FakeCalendar([event])],
+        now=now,
+        identities={USER_EMAIL: USER_ID},
+    )
+
+    assert state.keys == set()
+    assert state.deleted == [key]
 
 
 def test_participant_without_telegram_id_is_skipped(
@@ -355,7 +704,7 @@ def test_participant_without_telegram_id_is_skipped(
     )
     event = _weekly_event(now, email="unknown@example.com")
     sender = Mock()
-    timezone_getter = Mock(return_value=3)
+    timezone_getter = Mock(return_value=ZoneInfo("Europe/Moscow"))
 
     _run_poll_cycle(
         nc_calendar,

--- a/tests/test_caldav_repository.py
+++ b/tests/test_caldav_repository.py
@@ -1,0 +1,118 @@
+import importlib.util
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from source.caldav_notification_state import SentEventKey
+
+
+@dataclass(frozen=True)
+class Condition:
+    field_name: str
+    value: object
+
+
+class Field:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __eq__(self, value: object) -> Condition:
+        return Condition(self.name, value)
+
+
+class Statement:
+    def __init__(self, operation: str) -> None:
+        self.operation = operation
+        self.conditions: tuple[Condition, ...] = ()
+
+    def where(self, *conditions: Condition) -> "Statement":
+        self.conditions = conditions
+        return self
+
+
+class FakeCalDavSendData:
+    tg_id = Field("tg_id")
+    cooldown = Field("cooldown")
+    event_name = Field("event_name")
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.executed: list[Statement] = []
+
+    def execute(self, statement: Statement) -> None:
+        self.executed.append(statement)
+
+
+@pytest.fixture
+def repository_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[ModuleType, FakeSession]:
+    session = FakeSession()
+
+    @contextmanager
+    def get_session() -> Iterator[FakeSession]:
+        yield session
+
+    sqlalchemy = ModuleType("sqlalchemy")
+    sqlalchemy.delete = lambda model: Statement("delete")
+    sqlalchemy.select = lambda *fields: Statement("select")
+
+    db_module = ModuleType("source.db.db")
+    db_module.get_session = get_session
+
+    models_module = ModuleType("source.migrations.models")
+    models_module.CalDavSendData = FakeCalDavSendData
+
+    monkeypatch.setitem(sys.modules, "sqlalchemy", sqlalchemy)
+    monkeypatch.setitem(sys.modules, "source.db.db", db_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "source.migrations.models",
+        models_module,
+    )
+
+    module_path = (
+        Path(__file__).parents[1]
+        / "source"
+        / "db"
+        / "repos"
+        / "caldav_calendar.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "caldav_repository_under_test",
+        module_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return module, session
+
+
+def test_delete_sent_event_uses_exact_composite_key(
+    repository_module: tuple[ModuleType, FakeSession],
+) -> None:
+    repository, session = repository_module
+    key = SentEventKey(
+        telegram_id=101,
+        cooldown_minutes=60,
+        event_uid="team_sync_2026_instance",
+    )
+
+    repository.delete_sent_event(key)
+
+    assert len(session.executed) == 1
+    statement = session.executed[0]
+    assert statement.operation == "delete"
+    assert statement.conditions == (
+        Condition("tg_id", 101),
+        Condition("cooldown", 60),
+        Condition("event_name", "team_sync_2026_instance"),
+    )

--- a/tests/test_calendar_presentation.py
+++ b/tests/test_calendar_presentation.py
@@ -1,0 +1,359 @@
+import importlib
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, timedelta
+from types import ModuleType
+from unittest.mock import Mock
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from tests.caldav_fakes import (
+    FakeCalendar,
+    FakeCalendarParser,
+    FakeClient,
+    FakeComponent,
+    FakeEvent,
+    FakeICalendar,
+    FakeInlineKeyboardButton,
+    FakeInlineKeyboardMarkup,
+    FakeLogger,
+    FakePrincipal,
+    FrozenDateTime,
+)
+
+USER_ID = 101
+USER_EMAIL = "user@example.com"
+
+
+def _module(name: str, **attributes: object) -> ModuleType:
+    module = ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    return module
+
+
+def _ignore(*_args: object, **_kwargs: object) -> None:
+    pass
+
+
+@dataclass(frozen=True)
+class TemporalProperty:
+    dt: datetime | date
+    params: dict[str, object] = field(default_factory=dict)
+
+
+class RecordingCalendar(FakeCalendar):
+    def __init__(self, events: list[FakeEvent] | None = None) -> None:
+        super().__init__(events)
+        self.searches: list[tuple[datetime, datetime]] = []
+
+    def date_search(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        expand: bool = False,
+    ) -> list[FakeEvent]:
+        self.searches.append((start, end))
+        return super().date_search(
+            start=start,
+            end=end,
+            expand=expand,
+        )
+
+
+@pytest.fixture
+def calendar_module(monkeypatch: pytest.MonkeyPatch):
+    timezone_getter = Mock(return_value=ZoneInfo("Europe/Warsaw"))
+    config = _module(
+        "source.config",
+        WEB_CALDAV_URL="https://calendar.test/caldav",
+        USERNAME="nextcloud-user",
+        PASSWORD="nextcloud-password",
+        COOLDOWN_TUESDAY=2,
+        COOLDOWN_SUNDAY=10,
+        COOLDOWN_DEFAULT=2,
+        POLL_INTERVAL=60,
+        WEB_APP_URL="https://nextcloud.test",
+        UPDATE_INTERVAL=1,
+        TIMEZONE="Europe/Moscow",
+        CALDAV_USERNAME="caldav-user",
+        CALDAV_PASSWORD="caldav-password",
+        CALDAV_COOLDOWNS={},
+    )
+    modules = {
+        "source.config": config,
+        "source.connections.sender": _module(
+            "source.connections.sender",
+            send_message_limited=_ignore,
+        ),
+        "source.db.repos.users": _module(
+            "source.db.repos.users",
+            NEXTCLOUD_FIELD_MISSING=object(),
+            get_effective_timezone=timezone_getter,
+            get_tg_id_by_email=lambda _email: None,
+            update_nextcloud_profile=_ignore,
+        ),
+        "source.db.repos.caldav_calendar": _module(
+            "source.db.repos.caldav_calendar",
+            delete_sent_event=_ignore,
+            get_sent_event_keys=set,
+            save_event_send=_ignore,
+        ),
+        "source.app_logging": _module(
+            "source.app_logging",
+            logger=FakeLogger(),
+        ),
+    }
+    telebot_types = _module(
+        "telebot.types",
+        InlineKeyboardMarkup=FakeInlineKeyboardMarkup,
+        InlineKeyboardButton=FakeInlineKeyboardButton,
+    )
+    modules.update(
+        {
+            "telebot": _module("telebot", types=telebot_types),
+            "telebot.types": telebot_types,
+            "caldav": _module("caldav", DAVClient=None, error=Exception),
+            "icalendar": _module(
+                "icalendar",
+                Calendar=FakeCalendarParser,
+                vText=lambda value: value,
+            ),
+            "requests": _module("requests", get=_ignore),
+        }
+    )
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    monkeypatch.delitem(sys.modules, "source.nc_calendar", raising=False)
+    module = importlib.import_module("source.nc_calendar")
+    yield module, timezone_getter
+    sys.modules.pop("source.nc_calendar", None)
+
+
+def _participant() -> dict[str, object]:
+    return {
+        "email": USER_EMAIL,
+        "name": "User",
+        "role": "ATTENDEE",
+        "status": "NEEDS-ACTION",
+    }
+
+
+def _event(
+    start: datetime | date,
+    end: datetime | date,
+    *,
+    start_tzid: str | None = None,
+    end_tzid: str | None = None,
+    uid: str = "event-1",
+) -> FakeEvent:
+    start_params = {} if start_tzid is None else {"TZID": start_tzid}
+    end_params = {} if end_tzid is None else {"TZID": end_tzid}
+    component = FakeComponent(
+        {
+            "UID": uid,
+            "SUMMARY": "Team sync",
+            "DESCRIPTION": "Weekly team sync",
+            "LOCATION": "Online",
+            "DTSTART": TemporalProperty(start, start_params),
+            "DTEND": TemporalProperty(end, end_params),
+        },
+        participants=[_participant()],
+    )
+    return FakeEvent(FakeICalendar([component]))
+
+
+def _wire_calendar(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    calendar: RecordingCalendar,
+) -> None:
+    principal = FakePrincipal([calendar])
+    monkeypatch.setattr(
+        module,
+        "DAVClient",
+        lambda *_args, **_kwargs: FakeClient(principal),
+    )
+    monkeypatch.setattr(
+        module,
+        "get_all_participants",
+        lambda component: component.participants,
+    )
+    monkeypatch.setattr(
+        module,
+        "get_tg_id_by_email",
+        lambda email: USER_ID if email == USER_EMAIL else None,
+    )
+
+
+def test_calendar_message_uses_localized_weekday_and_time(
+    calendar_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, timezone_getter = calendar_module
+    timezone_getter.return_value = ZoneInfo("Europe/Moscow")
+    calendar = RecordingCalendar(
+        [
+            _event(
+                datetime(2026, 8, 12, 9),
+                datetime(2026, 8, 12, 10),
+                start_tzid="Europe/Warsaw",
+                end_tzid="Europe/Warsaw",
+            )
+        ]
+    )
+    _wire_calendar(module, monkeypatch, calendar)
+    FrozenDateTime.current = FrozenDateTime(
+        2026,
+        8,
+        11,
+        12,
+        tzinfo=UTC,
+    )
+    monkeypatch.setattr(module, "datetime", FrozenDateTime)
+
+    result = module.get_calendar(USER_ID, 7)
+
+    message, markup = result[0]
+    assert module.WEEKDAY_RU[2] in message
+    assert "Начало: 2026-08-12 10:00" in message
+    assert "Конец: 2026-08-12 11:00" in message
+    assert [button.text for button in markup.rows[0]] == [
+        "Принять",
+        "🔄",
+        "Отклонить",
+    ]
+    assert [button.callback_data for button in markup.rows[0]] == [
+        "c_ACCEPTED_event-1_NEEDS-ACTION_1",
+        "update_event-1_1",
+        "c_DECLINED_event-1_NEEDS-ACTION_1",
+    ]
+    timezone_getter.assert_called_once_with(
+        USER_ID,
+        default_tzid=module.TIMEZONE,
+    )
+
+
+def test_localized_weekday_changes_after_midnight(
+    calendar_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, timezone_getter = calendar_module
+    calendar = RecordingCalendar(
+        [
+            _event(
+                datetime(2026, 8, 10, 22, 30, tzinfo=UTC),
+                datetime(2026, 8, 10, 23, 30, tzinfo=UTC),
+            )
+        ]
+    )
+    _wire_calendar(module, monkeypatch, calendar)
+    FrozenDateTime.current = FrozenDateTime(
+        2026,
+        8,
+        10,
+        12,
+        tzinfo=UTC,
+    )
+    monkeypatch.setattr(module, "datetime", FrozenDateTime)
+
+    result = module.get_calendar(USER_ID, 7)
+
+    message = result[0][0]
+    assert module.WEEKDAY_RU[1] in message
+    assert "Начало: 2026-08-11 00:30" in message
+    assert "Конец: 2026-08-11 01:30" in message
+    timezone_getter.assert_called_once()
+
+
+@pytest.mark.parametrize("tzid", ["Europe/Warsaw", "Europe/Moscow"])
+def test_floating_refresh_message_uses_recipient_wall_time(
+    calendar_module,
+    monkeypatch: pytest.MonkeyPatch,
+    tzid: str,
+) -> None:
+    module, timezone_getter = calendar_module
+    timezone_getter.return_value = ZoneInfo(tzid)
+    calendar = RecordingCalendar(
+        [
+            _event(
+                datetime(2026, 10, 25, 9),
+                datetime(2026, 10, 25, 10),
+            )
+        ]
+    )
+    _wire_calendar(module, monkeypatch, calendar)
+    FrozenDateTime.current = FrozenDateTime(
+        2026,
+        10,
+        24,
+        12,
+        tzinfo=UTC,
+    )
+    monkeypatch.setattr(module, "datetime", FrozenDateTime)
+
+    message, _status = module.msg_design_from_button(
+        "event-1",
+        USER_ID,
+        1,
+    )
+
+    assert module.WEEKDAY_RU[6] in message
+    assert "Начало: 2026-10-25 09:00" in message
+    assert "Конец: 2026-10-25 10:00" in message
+    timezone_getter.assert_called_once()
+
+
+def test_today_window_uses_recipient_local_midnight(
+    calendar_module,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, timezone_getter = calendar_module
+    calendar = RecordingCalendar()
+    _wire_calendar(module, monkeypatch, calendar)
+    FrozenDateTime.current = FrozenDateTime(
+        2026,
+        3,
+        29,
+        10,
+        tzinfo=UTC,
+    )
+    monkeypatch.setattr(module, "datetime", FrozenDateTime)
+
+    assert module.get_calendar(USER_ID, 1) == []
+
+    start, end = calendar.searches[0]
+    assert start.isoformat() == "2026-03-29T00:00:00+01:00"
+    assert end.isoformat() == "2026-03-30T00:00:00+02:00"
+    assert end.astimezone(UTC) - start.astimezone(UTC) == timedelta(hours=23)
+    timezone_getter.assert_called_once()
+
+
+@pytest.mark.parametrize("cooldown", [6, 7])
+def test_week_window_uses_recipient_timezone(
+    calendar_module,
+    monkeypatch: pytest.MonkeyPatch,
+    cooldown: int,
+) -> None:
+    module, timezone_getter = calendar_module
+    calendar = RecordingCalendar()
+    _wire_calendar(module, monkeypatch, calendar)
+    FrozenDateTime.current = FrozenDateTime(
+        2026,
+        10,
+        22,
+        10,
+        tzinfo=UTC,
+    )
+    monkeypatch.setattr(module, "datetime", FrozenDateTime)
+
+    assert module.get_calendar(USER_ID, cooldown) == []
+
+    start, end = calendar.searches[0]
+    assert start.isoformat() == "2026-10-22T00:00:00+02:00"
+    assert end.isoformat() == "2026-10-29T00:00:00+01:00"
+    assert end.astimezone(UTC) - start.astimezone(UTC) == timedelta(hours=169)
+    timezone_getter.assert_called_once()

--- a/tests/test_calendar_time.py
+++ b/tests/test_calendar_time.py
@@ -1,0 +1,174 @@
+from datetime import UTC, date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from source.calendar_time import (
+    UnknownSourceTimezoneError,
+    local_day_window,
+    local_week_window,
+    localize_ical_value,
+)
+
+
+def test_utc_event_is_converted_to_recipient_timezone() -> None:
+    result = localize_ical_value(
+        datetime(2026, 8, 10, 22, 30, tzinfo=UTC),
+        target_timezone=ZoneInfo("Europe/Warsaw"),
+        source_tzid=None,
+    )
+
+    assert result.isoformat() == "2026-08-11T00:30:00+02:00"
+
+
+def test_offset_event_preserves_absolute_instant() -> None:
+    source = datetime(
+        2026,
+        1,
+        15,
+        8,
+        tzinfo=timezone(timedelta(hours=-5)),
+    )
+
+    result = localize_ical_value(
+        source,
+        target_timezone=ZoneInfo("Asia/Kolkata"),
+        source_tzid="Europe/Warsaw",
+    )
+
+    assert result.astimezone(UTC) == source.astimezone(UTC)
+    assert result.isoformat() == "2026-01-15T18:30:00+05:30"
+
+
+def test_aware_event_is_not_reinterpreted_from_tzid() -> None:
+    source = datetime(2026, 8, 10, 22, 30, tzinfo=UTC)
+
+    result = localize_ical_value(
+        source,
+        target_timezone=ZoneInfo("Europe/Warsaw"),
+        source_tzid="Asia/Kolkata",
+    )
+
+    assert result.astimezone(UTC) == source
+
+
+def test_tzid_event_preserves_absolute_instant() -> None:
+    result = localize_ical_value(
+        datetime(2026, 7, 15, 9),
+        target_timezone=ZoneInfo("Europe/Moscow"),
+        source_tzid="Europe/Warsaw",
+    )
+
+    assert result.isoformat() == "2026-07-15T10:00:00+03:00"
+    assert result.astimezone(UTC).hour == 7
+
+
+def test_floating_event_uses_recipient_wall_time() -> None:
+    result = localize_ical_value(
+        datetime(2026, 10, 25, 9),
+        target_timezone=ZoneInfo("Europe/Warsaw"),
+        source_tzid=None,
+    )
+
+    assert result.isoformat() == "2026-10-25T09:00:00+01:00"
+
+
+def test_floating_event_is_not_treated_as_utc() -> None:
+    source = datetime(2026, 10, 25, 9)
+    warsaw = localize_ical_value(
+        source,
+        target_timezone=ZoneInfo("Europe/Warsaw"),
+        source_tzid=None,
+    )
+    moscow = localize_ical_value(
+        source,
+        target_timezone=ZoneInfo("Europe/Moscow"),
+        source_tzid=None,
+    )
+
+    assert warsaw.hour == moscow.hour == 9
+    assert warsaw.astimezone(UTC) != moscow.astimezone(UTC)
+
+
+def test_all_day_event_remains_date() -> None:
+    source = date(2026, 8, 11)
+
+    result = localize_ical_value(
+        source,
+        target_timezone=ZoneInfo("Europe/Warsaw"),
+        source_tzid="Unknown/Still-Ignored-For-Date",
+    )
+
+    assert result is source
+
+
+def test_unknown_tzid_does_not_fall_back_to_utc() -> None:
+    with pytest.raises(UnknownSourceTimezoneError) as error:
+        localize_ical_value(
+            datetime(2026, 8, 11, 9),
+            target_timezone=ZoneInfo("Europe/Warsaw"),
+            source_tzid="Unknown/Nowhere",
+        )
+
+    assert error.value.tzid == "Unknown/Nowhere"
+
+
+def test_warsaw_winter_and_summer_offsets_are_different() -> None:
+    winter = localize_ical_value(
+        datetime(2026, 1, 15, 9),
+        target_timezone=ZoneInfo("Europe/Warsaw"),
+        source_tzid="Europe/Warsaw",
+    )
+    summer = localize_ical_value(
+        datetime(2026, 7, 15, 9),
+        target_timezone=ZoneInfo("Europe/Warsaw"),
+        source_tzid="Europe/Warsaw",
+    )
+
+    assert winter.utcoffset() == timedelta(hours=1)
+    assert summer.utcoffset() == timedelta(hours=2)
+
+
+def test_dst_overlap_uses_first_occurrence() -> None:
+    result = localize_ical_value(
+        datetime(2026, 10, 25, 2, 30),
+        target_timezone=ZoneInfo("Europe/Warsaw"),
+        source_tzid="Europe/Warsaw",
+    )
+
+    assert result.fold == 0
+    assert result.utcoffset() == timedelta(hours=2)
+    assert result.astimezone(UTC).isoformat() == "2026-10-25T00:30:00+00:00"
+
+
+def test_dst_gap_uses_pre_gap_offset() -> None:
+    result = localize_ical_value(
+        datetime(2026, 3, 29, 2, 30),
+        target_timezone=ZoneInfo("Europe/Warsaw"),
+        source_tzid="Europe/Warsaw",
+    )
+
+    assert result.isoformat() == "2026-03-29T03:30:00+02:00"
+    assert result.astimezone(UTC).isoformat() == "2026-03-29T01:30:00+00:00"
+
+
+def test_local_day_window_uses_dst_safe_midnights() -> None:
+    start, end = local_day_window(
+        datetime(2026, 3, 29, 10, tzinfo=UTC),
+        ZoneInfo("Europe/Warsaw"),
+    )
+
+    assert start.isoformat() == "2026-03-29T00:00:00+01:00"
+    assert end.isoformat() == "2026-03-30T00:00:00+02:00"
+    assert end.astimezone(UTC) - start.astimezone(UTC) == timedelta(hours=23)
+
+
+def test_local_week_window_keeps_local_midnight_across_dst() -> None:
+    start, end = local_week_window(
+        datetime(2026, 10, 22, 10, tzinfo=UTC),
+        ZoneInfo("Europe/Warsaw"),
+    )
+
+    assert start.isoformat() == "2026-10-22T00:00:00+02:00"
+    assert end.isoformat() == "2026-10-29T00:00:00+01:00"
+    assert end.astimezone(UTC) - start.astimezone(UTC) == timedelta(hours=169)

--- a/tests/test_datetime_formatting.py
+++ b/tests/test_datetime_formatting.py
@@ -14,10 +14,9 @@ def test_aware_calendar_datetime_uses_effective_timezone() -> None:
 
     assert (
         format_calendar_time(
-            instant,
-            ZoneInfo("Europe/Warsaw"),
+            instant.astimezone(ZoneInfo("Europe/Warsaw")),
         )
-        == "14:00"
+        == "2026-07-15 14:00"
     )
 
 
@@ -56,10 +55,9 @@ def test_invalid_stored_timezone_does_not_raise_type_error() -> None:
 
     assert (
         format_calendar_time(
-            datetime(2026, 1, 15, 12, tzinfo=UTC),
-            resolved,
+            datetime(2026, 1, 15, 12, tzinfo=UTC).astimezone(resolved),
         )
-        == "12:00"
+        == "2026-01-15 12:00"
     )
 
 

--- a/tests/test_datetime_formatting.py
+++ b/tests/test_datetime_formatting.py
@@ -1,0 +1,82 @@
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+from source.datetime_formatting import (
+    format_calendar_time,
+    format_task_due_date,
+)
+from source.scheduler import _format_changes_for_timezone
+from source.timezone import TimezoneSettings, resolve_effective_timezone
+
+
+def test_aware_calendar_datetime_uses_effective_timezone() -> None:
+    instant = datetime(2026, 7, 15, 12, tzinfo=UTC)
+
+    assert (
+        format_calendar_time(
+            instant,
+            ZoneInfo("Europe/Warsaw"),
+        )
+        == "14:00"
+    )
+
+
+def test_task_due_date_uses_effective_timezone() -> None:
+    instant = datetime(2026, 1, 15, 12, tzinfo=UTC)
+
+    assert (
+        format_task_due_date(
+            instant,
+            ZoneInfo("Asia/Kolkata"),
+        )
+        == "26-01-15 17:30"
+    )
+
+
+def test_task_utc_naive_datetime_remains_an_absolute_utc_instant() -> None:
+    utc_naive = datetime(2026, 1, 15, 12)
+
+    assert (
+        format_task_due_date(
+            utc_naive,
+            ZoneInfo("Asia/Kolkata"),
+        )
+        == "26-01-15 17:30"
+    )
+
+
+def test_invalid_stored_timezone_does_not_raise_type_error() -> None:
+    resolved = resolve_effective_timezone(
+        TimezoneSettings(
+            nextcloud_tzid="Invalid/Timezone",
+            override_tzid="Also/Invalid",
+        ),
+        default_tzid="Invalid/Default",
+    )
+
+    assert (
+        format_calendar_time(
+            datetime(2026, 1, 15, 12, tzinfo=UTC),
+            resolved,
+        )
+        == "12:00"
+    )
+
+
+def test_task_change_formatting_is_per_recipient() -> None:
+    old_due = datetime(2026, 1, 15, 12)
+    new_due = datetime(2026, 1, 15, 13)
+    changes = [[old_due, new_due]]
+
+    warsaw = _format_changes_for_timezone(
+        changes,
+        ZoneInfo("Europe/Warsaw"),
+    )
+    kolkata = _format_changes_for_timezone(
+        changes,
+        ZoneInfo("Asia/Kolkata"),
+    )
+
+    assert warsaw == ["Due: `26-01-15 13:00` → `26-01-15 14:00`"]
+    assert kolkata == ["Due: `26-01-15 17:30` → `26-01-15 18:30`"]
+    assert changes == [[old_due, new_due]]

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,202 @@
+from pathlib import Path
+
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import Engine
+
+from source.migrations.init_db import init_db
+from source.migrations.migration import auto_migrate
+
+
+def _database_url(tmp_path: Path, name: str) -> str:
+    return f"sqlite:///{tmp_path / name}"
+
+
+def _create_legacy_users(
+    database_url: str,
+    offsets: list[int],
+) -> Engine:
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "CREATE TABLE users ("
+                "tg_id BIGINT PRIMARY KEY, "
+                "nc_login VARCHAR(100) NOT NULL, "
+                "nc_time_zone INTEGER NOT NULL DEFAULT 3"
+                ")"
+            )
+        )
+        for tg_id, offset in enumerate(offsets, start=1):
+            connection.execute(
+                text(
+                    "INSERT INTO users "
+                    "(tg_id, nc_login, nc_time_zone) "
+                    "VALUES (:tg_id, :nc_login, :offset)"
+                ),
+                {
+                    "nc_login": f"user-{tg_id}",
+                    "offset": offset,
+                    "tg_id": tg_id,
+                },
+            )
+    return engine
+
+
+def _overrides(engine: Engine) -> list[str | None]:
+    with engine.connect() as connection:
+        result = connection.execute(
+            text("SELECT timezone_override FROM users ORDER BY tg_id")
+        )
+        return list(result.scalars())
+
+
+def test_migration_adds_timezone_columns_to_legacy_schema(
+    tmp_path: Path,
+) -> None:
+    database_url = _database_url(tmp_path, "legacy-columns.db")
+    engine = _create_legacy_users(database_url, [3])
+
+    auto_migrate(database_url)
+
+    column_names = {
+        column["name"] for column in inspect(engine).get_columns("users")
+    }
+    assert {"nc_timezone", "timezone_override"} <= column_names
+
+
+def test_migration_adapts_original_init_sql_user_schema(
+    tmp_path: Path,
+) -> None:
+    database_url = _database_url(tmp_path, "init-sql-users.db")
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "CREATE TABLE users ("
+                "tg_id BIGINT PRIMARY KEY, "
+                "nc_login VARCHAR(100) NOT NULL"
+                ")"
+            )
+        )
+        connection.execute(
+            text(
+                "INSERT INTO users (tg_id, nc_login) VALUES (1, 'legacy-user')"
+            )
+        )
+
+    auto_migrate(database_url)
+
+    column_names = {
+        column["name"] for column in inspect(engine).get_columns("users")
+    }
+    assert {
+        "nc_email",
+        "nc_time_zone",
+        "nc_timezone",
+        "timezone_override",
+        "nc_token",
+    } <= column_names
+    with engine.connect() as connection:
+        offset = connection.execute(
+            text("SELECT nc_time_zone FROM users WHERE tg_id = 1")
+        ).scalar_one()
+    assert offset == 3
+
+
+def test_migration_backfills_non_default_legacy_offset(
+    tmp_path: Path,
+) -> None:
+    database_url = _database_url(tmp_path, "legacy-offsets.db")
+    engine = _create_legacy_users(database_url, [-12, 0, 4, -5, 14])
+
+    auto_migrate(database_url)
+
+    assert _overrides(engine) == [
+        "Etc/GMT+12",
+        "Etc/UTC",
+        "Etc/GMT-4",
+        "Etc/GMT+5",
+        "Etc/GMT-14",
+    ]
+
+
+def test_migration_does_not_treat_legacy_default_as_override(
+    tmp_path: Path,
+) -> None:
+    database_url = _database_url(tmp_path, "legacy-default.db")
+    engine = _create_legacy_users(database_url, [3])
+
+    auto_migrate(database_url)
+
+    assert _overrides(engine) == [None]
+
+
+def test_migration_ignores_out_of_range_legacy_offset(
+    tmp_path: Path,
+) -> None:
+    database_url = _database_url(tmp_path, "legacy-out-of-range.db")
+    engine = _create_legacy_users(database_url, [-13, 15])
+
+    auto_migrate(database_url)
+
+    assert _overrides(engine) == [None, None]
+
+
+def test_migration_is_safe_on_fresh_database(tmp_path: Path) -> None:
+    database_url = _database_url(tmp_path, "fresh.db")
+    engine = create_engine(database_url)
+    init_db(engine)
+
+    auto_migrate(database_url)
+
+    column_names = {
+        column["name"] for column in inspect(engine).get_columns("users")
+    }
+    assert {"nc_timezone", "timezone_override"} <= column_names
+
+
+def test_migration_is_idempotent_across_application_restarts(
+    tmp_path: Path,
+) -> None:
+    database_url = _database_url(tmp_path, "repeated.db")
+    engine = _create_legacy_users(database_url, [4])
+
+    auto_migrate(database_url)
+    auto_migrate(database_url)
+
+    assert _overrides(engine) == ["Etc/GMT-4"]
+    with engine.connect() as connection:
+        revisions = connection.execute(
+            text("SELECT version_num FROM alembic_version")
+        ).scalars()
+        assert list(revisions) == ["0001_user_timezones"]
+
+
+def test_migration_replaces_orphaned_runtime_revision(
+    tmp_path: Path,
+) -> None:
+    database_url = _database_url(tmp_path, "orphaned-revision.db")
+    engine = _create_legacy_users(database_url, [4])
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "CREATE TABLE alembic_version ("
+                "version_num VARCHAR(32) NOT NULL PRIMARY KEY"
+                ")"
+            )
+        )
+        connection.execute(
+            text(
+                "INSERT INTO alembic_version (version_num) "
+                "VALUES ('runtime_generated')"
+            )
+        )
+
+    auto_migrate(database_url)
+
+    assert _overrides(engine) == ["Etc/GMT-4"]
+    with engine.connect() as connection:
+        revisions = connection.execute(
+            text("SELECT version_num FROM alembic_version")
+        ).scalars()
+        assert list(revisions) == ["0001_user_timezones"]

--- a/tests/test_nextcloud_profile_sync.py
+++ b/tests/test_nextcloud_profile_sync.py
@@ -1,0 +1,196 @@
+import ast
+import inspect
+import logging
+import textwrap
+
+from source import nc_calendar
+from source.callbacks import complete_login_flow_profile
+from source.db.repos.users import NEXTCLOUD_FIELD_MISSING
+from source.nc_calendar import sync_nextcloud_users_once
+
+
+class FakeResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_login_flow_uses_app_password_for_self_profile() -> None:
+    calls: list[dict] = []
+    saved: list[dict] = []
+
+    def request_get(url: str, **kwargs: object) -> FakeResponse:
+        calls.append({"url": url, **kwargs})
+        return FakeResponse(
+            {
+                "ocs": {
+                    "data": {
+                        "id": "alice",
+                        "email": "alice@example.test",
+                        "timezone": "Europe/Warsaw",
+                    }
+                }
+            }
+        )
+
+    def save_profile(*args: object, **kwargs: object) -> None:
+        saved.append({"args": args, "kwargs": kwargs})
+
+    complete_login_flow_profile(
+        42,
+        {"loginName": "login-flow-user", "appPassword": "secret"},
+        base_url="https://nextcloud.example.test",
+        request_get=request_get,
+        save_profile=save_profile,
+    )
+
+    assert calls[0]["url"].endswith("/ocs/v2.php/cloud/user")
+    assert calls[0]["auth"] == ("login-flow-user", "secret")
+    assert saved[0]["kwargs"]["timezone_value"] == "Europe/Warsaw"
+
+
+def test_login_flow_passes_missing_timezone_sentinel() -> None:
+    saved: list[dict] = []
+
+    def request_get(_url: str, **_kwargs: object) -> FakeResponse:
+        return FakeResponse(
+            {
+                "ocs": {
+                    "data": {
+                        "id": "alice",
+                        "email": "alice@example.test",
+                    }
+                }
+            }
+        )
+
+    def save_profile(*args: object, **kwargs: object) -> None:
+        saved.append({"args": args, "kwargs": kwargs})
+
+    complete_login_flow_profile(
+        42,
+        {"loginName": "alice", "appPassword": "secret"},
+        base_url="https://nextcloud.example.test",
+        request_get=request_get,
+        save_profile=save_profile,
+    )
+
+    assert saved[0]["kwargs"]["timezone_value"] is NEXTCLOUD_FIELD_MISSING
+
+
+def test_login_flow_does_not_log_app_password(
+    caplog,
+) -> None:
+    def request_get(_url: str, **_kwargs: object) -> FakeResponse:
+        return FakeResponse(
+            {"ocs": {"data": {"id": "alice", "timezone": "UTC"}}}
+        )
+
+    with caplog.at_level(logging.DEBUG):
+        complete_login_flow_profile(
+            42,
+            {"loginName": "alice", "appPassword": "top-secret"},
+            base_url="https://nextcloud.example.test",
+            request_get=request_get,
+            save_profile=lambda *args, **kwargs: None,
+        )
+
+    assert "top-secret" not in caplog.text
+
+
+def test_admin_sync_passes_email_and_timezone_in_one_write() -> None:
+    calls: list[dict] = []
+
+    def request_get(url: str, **_kwargs: object) -> FakeResponse:
+        if url.endswith("cloud/users?limit=1000"):
+            return FakeResponse({"ocs": {"data": {"users": ["alice"]}}})
+        return FakeResponse(
+            {
+                "ocs": {
+                    "data": {
+                        "email": "alice@example.test",
+                        "timezone": "Europe/Warsaw",
+                    }
+                }
+            }
+        )
+
+    def update_profile(login: str, **kwargs: object) -> bool:
+        calls.append({"login": login, **kwargs})
+        return True
+
+    assert (
+        sync_nextcloud_users_once(
+            request_get=request_get,
+            update_profile=update_profile,
+        )
+        == 1
+    )
+    assert calls == [
+        {
+            "login": "alice",
+            "email": "alice@example.test",
+            "timezone_value": "Europe/Warsaw",
+        }
+    ]
+
+
+def test_admin_sync_updates_timezone_without_email() -> None:
+    calls: list[dict] = []
+
+    def request_get(url: str, **_kwargs: object) -> FakeResponse:
+        if url.endswith("cloud/users?limit=1000"):
+            return FakeResponse({"ocs": {"data": {"users": ["alice"]}}})
+        return FakeResponse({"ocs": {"data": {"timezone": "Asia/Kolkata"}}})
+
+    def update_profile(login: str, **kwargs: object) -> bool:
+        calls.append({"login": login, **kwargs})
+        return True
+
+    sync_nextcloud_users_once(
+        request_get=request_get,
+        update_profile=update_profile,
+    )
+
+    assert calls[0]["email"] is NEXTCLOUD_FIELD_MISSING
+    assert calls[0]["timezone_value"] == "Asia/Kolkata"
+
+
+def test_nextcloud_profile_sync_paths_are_read_only() -> None:
+    methods: list[str] = []
+
+    def request_get(url: str, **_kwargs: object) -> FakeResponse:
+        methods.append("GET")
+        if url.endswith("cloud/users?limit=1000"):
+            return FakeResponse({"ocs": {"data": {"users": ["alice"]}}})
+        return FakeResponse({"ocs": {"data": {"timezone": "UTC"}}})
+
+    sync_nextcloud_users_once(
+        request_get=request_get,
+        update_profile=lambda login, **kwargs: True,
+    )
+
+    assert methods == ["GET", "GET"]
+
+
+def test_periodic_calendar_polling_does_not_write_to_caldav() -> None:
+    source = textwrap.dedent(inspect.getsource(nc_calendar.poll_events))
+    tree = ast.parse(source)
+    called_names = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    called_attributes = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+
+    assert "set_all_attendees_needs_action" not in called_names
+    assert called_attributes.isdisjoint({"put", "save"})

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+from typing import NoReturn
+
+import pytest
+
+from source import app
+
+
+class _StopRun(BaseException):
+    pass
+
+
+class _WorkerThread:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    def start(self) -> None:
+        self._events.append("worker")
+
+
+def test_migrations_finish_before_background_workers_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    monkeypatch.setattr(app, "init_db", lambda: events.append("init"))
+    monkeypatch.setattr(
+        app,
+        "auto_migrate",
+        lambda: events.append("migrate"),
+    )
+    monkeypatch.setattr(app, "is_debug", lambda: False)
+    monkeypatch.setattr(app, "_notify_startup", lambda: None)
+    monkeypatch.setattr(app, "CALDAV_PASSWORD", None)
+    monkeypatch.setattr(app, "CALDAV_USERNAME", None)
+    monkeypatch.setattr(
+        app.threading,
+        "Thread",
+        lambda **_kwargs: _WorkerThread(events),
+    )
+    monkeypatch.setattr(
+        app.bot,
+        "remove_webhook",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        app.bot,
+        "get_me",
+        lambda: SimpleNamespace(username="test", id=1),
+    )
+
+    def stop_polling(**_kwargs: object) -> NoReturn:
+        events.append("polling")
+        raise _StopRun
+
+    monkeypatch.setattr(app.bot, "infinity_polling", stop_polling)
+
+    with pytest.raises(_StopRun):
+        app.run()
+
+    assert events[:2] == ["init", "migrate"]
+    assert events.count("worker") == 3
+    assert events[-1] == "polling"

--- a/tests/test_test_setup.py
+++ b/tests/test_test_setup.py
@@ -1,0 +1,10 @@
+import sys
+from importlib.util import find_spec
+
+
+def test_supported_python_runtime() -> None:
+    assert sys.version_info >= (3, 11)
+
+
+def test_source_package_is_discoverable() -> None:
+    assert find_spec("source") is not None

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,132 @@
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from source.timezone import (
+    TimezoneSettings,
+    normalize_tzid,
+    resolve_effective_timezone,
+)
+
+
+def test_timezone_settings_are_frozen_and_slotted() -> None:
+    settings = TimezoneSettings(
+        nextcloud_tzid="Europe/Berlin",
+        override_tzid=None,
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        settings.override_tzid = "UTC"  # type: ignore[misc]
+
+    assert not hasattr(settings, "__dict__")
+
+
+def test_normalize_tzid_trims_valid_iana_identifier() -> None:
+    assert normalize_tzid("  Europe/Berlin  ") == "Europe/Berlin"
+
+
+def test_normalize_tzid_rejects_empty_value() -> None:
+    assert normalize_tzid("") is None
+    assert normalize_tzid("  \t\n") is None
+
+
+def test_normalize_tzid_rejects_non_string() -> None:
+    assert normalize_tzid(None) is None
+    assert normalize_tzid(3) is None
+    assert normalize_tzid(object()) is None
+
+
+def test_normalize_tzid_rejects_unknown_identifier() -> None:
+    assert normalize_tzid("Mars/Olympus_Mons") is None
+
+
+def test_normalize_tzid_rejects_invalid_zoneinfo_key() -> None:
+    assert normalize_tzid("../Europe/Warsaw") is None
+    assert normalize_tzid("A" * 256) is None
+
+
+def test_override_has_highest_priority() -> None:
+    settings = TimezoneSettings(
+        nextcloud_tzid="Europe/Berlin",
+        override_tzid="Asia/Kolkata",
+    )
+
+    resolved = resolve_effective_timezone(
+        settings,
+        default_tzid="Europe/Moscow",
+    )
+
+    assert isinstance(resolved, ZoneInfo)
+    assert resolved.key == "Asia/Kolkata"
+
+
+def test_invalid_override_does_not_block_nextcloud_timezone() -> None:
+    settings = TimezoneSettings(
+        nextcloud_tzid="Europe/Berlin",
+        override_tzid="Invalid/Override",
+    )
+
+    resolved = resolve_effective_timezone(
+        settings,
+        default_tzid="Europe/Moscow",
+    )
+
+    assert isinstance(resolved, ZoneInfo)
+    assert resolved.key == "Europe/Berlin"
+
+
+def test_default_is_used_when_user_timezones_are_unavailable() -> None:
+    settings = TimezoneSettings(
+        nextcloud_tzid="Invalid/Nextcloud",
+        override_tzid=None,
+    )
+
+    resolved = resolve_effective_timezone(
+        settings,
+        default_tzid="Europe/Moscow",
+    )
+
+    assert isinstance(resolved, ZoneInfo)
+    assert resolved.key == "Europe/Moscow"
+
+
+def test_utc_is_used_when_all_configured_timezones_are_invalid() -> None:
+    settings = TimezoneSettings(
+        nextcloud_tzid="Invalid/Nextcloud",
+        override_tzid="Invalid/Override",
+    )
+
+    resolved = resolve_effective_timezone(
+        settings,
+        default_tzid="Invalid/Default",
+    )
+
+    assert resolved is UTC
+
+
+def test_european_timezone_observes_dst() -> None:
+    resolved = resolve_effective_timezone(
+        TimezoneSettings(nextcloud_tzid="Europe/Berlin"),
+        default_tzid="UTC",
+    )
+
+    winter = datetime(2026, 1, 15, tzinfo=UTC)
+    summer = datetime(2026, 7, 15, tzinfo=UTC)
+
+    assert winter.astimezone(resolved).utcoffset() == timedelta(hours=1)
+    assert summer.astimezone(resolved).utcoffset() == timedelta(hours=2)
+
+
+def test_asia_kolkata_keeps_half_hour_offset() -> None:
+    resolved = resolve_effective_timezone(
+        TimezoneSettings(override_tzid="Asia/Kolkata"),
+        default_tzid="UTC",
+    )
+    instant = datetime(2026, 1, 15, tzinfo=UTC)
+
+    assert instant.astimezone(resolved).utcoffset() == timedelta(
+        hours=5,
+        minutes=30,
+    )

--- a/tests/test_timezone_command.py
+++ b/tests/test_timezone_command.py
@@ -1,0 +1,78 @@
+import pytest
+
+from source.timezone_command import (
+    InvalidTimezoneInput,
+    apply_timezone_argument,
+)
+
+
+def test_timezone_command_sets_valid_override() -> None:
+    saved: list[str] = []
+
+    result = apply_timezone_argument(
+        " Europe/Warsaw ",
+        save_override=saved.append,
+        clear_override=lambda: None,
+    )
+
+    assert saved == ["Europe/Warsaw"]
+    assert "Europe/Warsaw" in result
+
+
+def test_timezone_auto_clears_override() -> None:
+    cleared: list[bool] = []
+
+    result = apply_timezone_argument(
+        "AUTO",
+        save_override=lambda value: None,
+        clear_override=lambda: cleared.append(True),
+    )
+
+    assert cleared == [True]
+    assert "Nextcloud" in result
+
+
+def test_timezone_command_rejects_integer_offset() -> None:
+    with pytest.raises(InvalidTimezoneInput):
+        apply_timezone_argument(
+            "+3",
+            save_override=lambda value: None,
+            clear_override=lambda: None,
+        )
+
+
+def test_timezone_command_rejects_unknown_zone() -> None:
+    with pytest.raises(InvalidTimezoneInput):
+        apply_timezone_argument(
+            "Mars/Olympus",
+            save_override=lambda value: None,
+            clear_override=lambda: None,
+        )
+
+
+def test_timezone_command_does_not_report_success_after_repository_error() -> (
+    None
+):
+    def fail(_value: str) -> None:
+        raise RuntimeError("database unavailable")
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        apply_timezone_argument(
+            "Europe/Warsaw",
+            save_override=fail,
+            clear_override=lambda: None,
+        )
+
+
+def test_timezone_command_never_writes_to_nextcloud() -> None:
+    local_writes: list[str] = []
+    nextcloud_writes: list[str] = []
+
+    apply_timezone_argument(
+        "Europe/Moscow",
+        save_override=local_writes.append,
+        clear_override=lambda: None,
+    )
+
+    assert local_writes == ["Europe/Moscow"]
+    assert nextcloud_writes == []

--- a/tests/test_user_timezone_repository.py
+++ b/tests/test_user_timezone_repository.py
@@ -1,0 +1,235 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from source.db.repos import users
+from source.migrations.models import NextCloudLogin, User
+
+
+@pytest.fixture
+def session_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> sessionmaker[Session]:
+    engine = create_engine("sqlite:///:memory:")
+    User.__table__.create(engine)
+    NextCloudLogin.__table__.create(engine)
+    factory = sessionmaker(bind=engine)
+
+    @contextmanager
+    def test_session() -> Iterator[Session]:
+        session = factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    monkeypatch.setattr(users, "get_session", test_session)
+    return factory
+
+
+def _add_user(
+    factory: sessionmaker[Session],
+    *,
+    tg_id: int = 1,
+    timezone: str | None = "Europe/Berlin",
+) -> None:
+    with factory.begin() as session:
+        session.add(
+            User(
+                tg_id=tg_id,
+                nc_login=f"user-{tg_id}",
+                nc_email="old@example.test",
+                nc_timezone=timezone,
+            )
+        )
+
+
+def _user(factory: sessionmaker[Session], tg_id: int = 1) -> User:
+    with factory() as session:
+        return session.execute(
+            select(User).where(User.tg_id == tg_id)
+        ).scalar_one()
+
+
+def test_login_flow_saves_nextcloud_timezone(
+    session_factory: sessionmaker[Session],
+) -> None:
+    with session_factory.begin() as session:
+        session.add(NextCloudLogin(tg_id=1, token="poll-token"))
+
+    users.save_login_profile(
+        1,
+        "alice",
+        "Alice@Example.test",
+        "app-password",
+        timezone_value=" Europe/Warsaw ",
+    )
+
+    stored = _user(session_factory)
+    assert stored.nc_login == "alice"
+    assert stored.nc_email == "alice@example.test"
+    assert stored.nc_token == "app-password"
+    assert stored.nc_timezone == "Europe/Warsaw"
+    with session_factory() as session:
+        assert session.get(NextCloudLogin, 1) is None
+
+
+def test_login_flow_accepts_missing_timezone_from_nextcloud_31(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _add_user(session_factory)
+
+    users.save_login_profile(
+        1,
+        "user-1",
+        "new@example.test",
+        "new-token",
+        timezone_value=users.NEXTCLOUD_FIELD_MISSING,
+    )
+
+    assert _user(session_factory).nc_timezone == "Europe/Berlin"
+
+
+def test_login_flow_stores_empty_timezone_as_none(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _add_user(session_factory)
+
+    users.save_login_profile(
+        1,
+        "user-1",
+        "new@example.test",
+        "new-token",
+        timezone_value="   ",
+    )
+
+    assert _user(session_factory).nc_timezone is None
+
+
+def test_login_flow_ignores_invalid_timezone(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _add_user(session_factory)
+
+    users.save_login_profile(
+        1,
+        "user-1",
+        "new@example.test",
+        "new-token",
+        timezone_value="Invalid/Timezone",
+    )
+
+    assert _user(session_factory).nc_timezone == "Europe/Berlin"
+
+
+def test_admin_sync_updates_email_and_timezone_atomically(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _add_user(session_factory)
+
+    assert users.update_nextcloud_profile(
+        "user-1",
+        email="new@example.test",
+        timezone_value="Asia/Kolkata",
+    )
+
+    stored = _user(session_factory)
+    assert stored.nc_email == "new@example.test"
+    assert stored.nc_timezone == "Asia/Kolkata"
+
+
+def test_admin_sync_rolls_back_profile_after_timezone_error(
+    session_factory: sessionmaker[Session],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _add_user(session_factory)
+
+    def fail_timezone_update(_user: User, _value: object) -> None:
+        raise RuntimeError("timezone update failed")
+
+    monkeypatch.setattr(
+        users,
+        "_apply_nextcloud_timezone",
+        fail_timezone_update,
+    )
+
+    with pytest.raises(RuntimeError, match="timezone update failed"):
+        users.update_nextcloud_profile(
+            "user-1",
+            email="new@example.test",
+            timezone_value="Asia/Kolkata",
+        )
+
+    stored = _user(session_factory)
+    assert stored.nc_email == "old@example.test"
+    assert stored.nc_timezone == "Europe/Berlin"
+
+
+def test_admin_sync_updates_timezone_without_email(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _add_user(session_factory)
+
+    users.update_nextcloud_profile(
+        "user-1",
+        timezone_value="Europe/Warsaw",
+    )
+
+    stored = _user(session_factory)
+    assert stored.nc_email == "old@example.test"
+    assert stored.nc_timezone == "Europe/Warsaw"
+
+
+def test_admin_sync_clears_explicit_empty_timezone(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _add_user(session_factory)
+
+    users.update_nextcloud_profile("user-1", timezone_value=None)
+
+    assert _user(session_factory).nc_timezone is None
+
+
+def test_admin_sync_preserves_timezone_when_field_is_missing(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _add_user(session_factory)
+
+    users.update_nextcloud_profile(
+        "user-1",
+        email="new@example.test",
+    )
+
+    assert _user(session_factory).nc_timezone == "Europe/Berlin"
+
+
+def test_admin_sync_preserves_timezone_when_value_is_invalid(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _add_user(session_factory)
+
+    users.update_nextcloud_profile(
+        "user-1",
+        timezone_value="Mars/Olympus",
+    )
+
+    assert _user(session_factory).nc_timezone == "Europe/Berlin"
+
+
+def test_timezone_override_round_trip(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _add_user(session_factory)
+
+    users.set_timezone_override(1, " Europe/Warsaw ")
+    assert _user(session_factory).timezone_override == "Europe/Warsaw"
+
+    users.clear_timezone_override(1)
+    assert _user(session_factory).timezone_override is None


### PR DESCRIPTION
## Problem

CalDAV `DATE-TIME` values without `Z` or `TZID` are floating wall time, but the bot treated naive values as UTC. Calendar messages could therefore show the correct converted time with the wrong date or weekday, user-facing day windows were built in a shared timezone, and periodic cooldowns were evaluated once per event instead of per recipient.

## Solution

- add a pure RFC 5545 temporal layer for aware, TZID-bound, floating, and all-day values;
- localize start/end once per recipient and use the localized date, time, weekday, and sort key consistently;
- build `/calendar_today` and weekly queries from recipient-local aware midnights;
- keep the periodic query as an absolute UTC 24-hour interval;
- evaluate floating-event cooldowns independently for every attendee;
- treat unknown source TZID as an incomplete scan so stale local state is preserved;
- retain the read-only CalDAV guarantee: periodic polling never saves events or mutates attendee parameters.

## Dependencies

This branch linearly stacks the completed work for #65 and #66 because those foundations are not yet present in `main`. There are no merge commits.

## Validation

- `pytest -q`: 95 passed;
- 100% branch coverage for the pure calendar-time, timezone, and notification-state modules;
- strict Ruff lint and format checks pass;
- UTC midnight crossing, floating Warsaw/Moscow cooldowns, DST gaps/overlaps, local day/week boundaries, incomplete scans, and read-only polling are covered by behavioral tests.

## Non-goals

No timezone migration redesign, `/timezone` redesign, scheduler/deadline semantic changes, recurring-window expansion, Telegram button changes, or CalDAV writes are introduced by the #67 portion.

Closes #67
